### PR TITLE
Improve matches export and player error messages

### DIFF
--- a/client/src/pages/matches/MatchesTable.jsx
+++ b/client/src/pages/matches/MatchesTable.jsx
@@ -114,6 +114,28 @@ const MatchesTable = () => {
         }
     };
 
+
+    //export to excel
+    const flattenMatchesForExcel = (matches) => {
+    return matches.map((m) => ({
+        Date: dayjs(m.date).format("DD/MM/YYYY"),
+        StartTime: m.startTime,
+        EndTime: m.endTime,
+        Location: m?.location?.name || "",
+        Address: m?.location?.address || "",
+        Status: m.status,
+        Courts: m.courts?.map((c) => `Court ${c.courtNumber}`).join(", "),
+        Players: m.players
+            ?.map((p) => `${p.user?.name} ${p.user?.lastname}`)
+            .join(", "),
+        PlayersCount: m.players?.length || 0,
+        CreatedBy: m.createdBy
+            ? `${m.createdBy.name} ${m.createdBy.lastname}`
+            : "",
+        Price: m.price,
+    }));
+};
+
     /* -------------------------------------------------- */
     /* TABLE COLUMNS                                      */
     /* -------------------------------------------------- */
@@ -254,7 +276,7 @@ const MatchesTable = () => {
             <Title level={3}>All matches</Title>
             <Text type="secondary">View all matches and manage status</Text>
 
-            <ExportToExcel fileName="matches.xlsx" data={matches} />
+            <ExportToExcel fileName="matches.xlsx" data={flattenMatchesForExcel(matches)} />
 
             <Table
                 columns={columns}

--- a/client/src/pages/players/PlayersTable.jsx
+++ b/client/src/pages/players/PlayersTable.jsx
@@ -62,6 +62,7 @@ const PlayersTable = ({ players, loading, fetchPlayers }) => {
 
         } catch (error) {
             console.log(error);
+            toast.error( error?.response?.data?.message ||'There was an issue toggling player account')
         }
     };
 
@@ -72,7 +73,7 @@ const PlayersTable = ({ players, loading, fetchPlayers }) => {
             fetchPlayers();
         } catch (error) {
             console.log(error);
-            toast.error(error?.response?.data?.message);
+            toast.error(error?.response?.data?.message || 'There was an issue toggling user status');
         }
     };
 


### PR DESCRIPTION
Add flattenMatchesForExcel to MatchesTable.jsx to format match data (date, times, location, courts, players, counts, creator, price) before passing to ExportToExcel. Update ExportToExcel call to use the flattened payload. In PlayersTable.jsx add fallback toast.error messages in two catch blocks to show a default message when the error response lacks a message, improving error handling and UX.