### PR TITLE
Add TennisLoader and dashboard refresh

### DIFF
--- a/client/src/components/Animations/TennisLoader.jsx
+++ b/client/src/components/Animations/TennisLoader.jsx
@@ -1,0 +1,10 @@
+
+const TennisLoader = () => {
+    return (
+        <div className="tennis-loader">
+            🎾
+        </div>
+    )
+}
+
+export default TennisLoader

--- a/client/src/pages/dashboard/AdminDashboard.jsx
+++ b/client/src/pages/dashboard/AdminDashboard.jsx
@@ -1,45 +1,119 @@
-import { Row, Col, Empty } from "antd"
-import WeatherCard from "../../components/common/WeatherCard"
-import UpComingMatches from "../../components/matches/UpComingMatches"
-import { useMatches } from "../../context/MatchContext"
-import PendingTransactions from "../../components/wallet/PendingTransactions"
-import { usePendingTransactions } from "../../hooks/useTransactions"
+import { Row, Col, Empty, Space, Typography, Button, Spin } from "antd";
+import { ReloadOutlined } from "@ant-design/icons";
 
+import WeatherCard from "../../components/common/WeatherCard";
+import UpComingMatches from "../../components/matches/UpComingMatches";
+import PendingTransactions from "../../components/wallet/PendingTransactions";
+import TennisLoader from "../../components/Animations/TennisLoader";
 
+import { useMatches } from "../../context/MatchContext";
+import { usePendingTransactions } from "../../hooks/useTransactions";
+
+const { Title } = Typography;
 
 const AdminDashboard = () => {
 
-  const { matches, loadMatches } = useMatches();
-  const { pendingTransactions, setLoadPendingTransactions , fetchPendingTransactions} = usePendingTransactions()
+  const {
+    openMatches,
+    loadOpenMatches,
+    fetchOpenMatches,
+  } = useMatches();
 
-  const upcomingMatches = matches.filter((m) => m?.status === 'Open')
+  const {
+    pendingTransactions,
+    loadPendingTransactions,
+    setLoadPendingTransactions,
+    fetchPendingTransactions,
+  } = usePendingTransactions();
+
+  const upcomingMatches = openMatches.filter(
+    (m) => m?.status !== "Played"
+  );
+
+  const loading = loadOpenMatches || loadPendingTransactions;
+
+  const refreshDashboard = async () => {
+    await Promise.all([
+      fetchOpenMatches(),
+      fetchPendingTransactions(),
+    ]);
+  };
 
   return (
     <>
-      <Row gutter={[16, 16]} >
-        <Col lg={8} md={12} sm={16} xs={24}  >
-          <WeatherCard />
-        </Col>
-        <Col lg={8} md={12} sm={16} xs={24}   >
-          {
-            upcomingMatches.length === 0 ? (
-              <Empty description="No up coming matches available" />) : (
-              <UpComingMatches matches={upcomingMatches} loadMatches={loadMatches} />
-            )
-          }
-        </Col>
-        <Col lg={8} md={12} sm={16} xs={24}>
-          <PendingTransactions
-            transactions={pendingTransactions}
-            setLoading={setLoadPendingTransactions}
-            fetchTransactions={fetchPendingTransactions}
-          />
-        </Col>
-      </Row>
+      <Space
+        style={{
+          width: "100%",
+          justifyContent: "space-between",
+          marginBottom: 20,
+          alignItems: "center",
+        }}
+      >
+        <Title level={3} style={{ margin: 0 }}>
+          🛠️ Admin Dashboard
+        </Title>
 
-      {/* <FeedbackModal open={true} /> */}
+        <Button
+          type="primary"
+          icon={<ReloadOutlined spin={loading} />}
+          disabled={loading}
+          onClick={refreshDashboard}
+          size="large"
+          style={{
+            background: "linear-gradient(135deg, #7CB342 0%, #43A047 100%)",
+            border: "none",
+            borderRadius: 999,
+            fontWeight: 700,
+            paddingInline: 24,
+            boxShadow: "0 6px 16px rgba(67,160,71,.35)",
+            transition: "all .25s ease",
+          }}
+          onMouseEnter={(e) => {
+            e.currentTarget.style.transform = "translateY(-2px)";
+            e.currentTarget.style.boxShadow =
+              "0 10px 24px rgba(67,160,71,.45)";
+          }}
+          onMouseLeave={(e) => {
+            e.currentTarget.style.transform = "translateY(0)";
+            e.currentTarget.style.boxShadow =
+              "0 6px 16px rgba(67,160,71,.35)";
+          }}
+        >
+          {loading ? "Refreshing..." : "Refresh Dashboard"}
+        </Button>
+      </Space>
+
+      <Spin
+        spinning={loading}
+        indicator={<TennisLoader />}
+      >
+        <Row gutter={[16, 16]}>
+          <Col lg={8} md={12} sm={16} xs={24}>
+            <WeatherCard />
+          </Col>
+
+          <Col lg={8} md={12} sm={16} xs={24}>
+            {upcomingMatches.length === 0 ? (
+              <Empty description="No upcoming matches available" />
+            ) : (
+              <UpComingMatches
+                matches={upcomingMatches}
+                loadMatches={loadOpenMatches}
+              />
+            )}
+          </Col>
+
+          <Col lg={8} md={12} sm={16} xs={24}>
+            <PendingTransactions
+              transactions={pendingTransactions}
+              setLoading={setLoadPendingTransactions}
+              fetchTransactions={fetchPendingTransactions}
+            />
+          </Col>
+        </Row>
+      </Spin>
     </>
-  )
-}
+  );
+};
 
-export default AdminDashboard
+export default AdminDashboard;

--- a/client/src/pages/dashboard/UserDashboard.jsx
+++ b/client/src/pages/dashboard/UserDashboard.jsx
@@ -1,19 +1,81 @@
 import { useMatches } from "../../context/MatchContext"
 import JoinMatch from "../../components/matches/JoinMatch";
+import { Button, Space, Spin, Typography } from "antd";
+import { ReloadOutlined } from "@ant-design/icons";
+import "../../styles/Loader.css";
+import TennisLoader from "../../components/Animations/TennisLoader";
+
+const { Title } = Typography;
 
 const UserDashboard = () => {
 
+
   const { openMatches, loadOpenMatches, fetchOpenMatches } = useMatches();
 
-  // const openMatches = [...matches]
-  //   .filter(m => m.status === 'Open' || m.status === 'Full' || m.status === 'Ready'  )
-  //   .sort((a, b) => new Date(a.date) - new Date(b.date))
+  const openMatch = openMatches.filter(
+    (match) => match.status !== "Played"
+  );
 
   return (
     <>
-      <JoinMatch openMatches={openMatches} loading={loadOpenMatches} fetchMatches={fetchOpenMatches} />
-    </>
-  )
-}
+      <Space
+        style={{
+          width: "100%",
+          justifyContent: "space-between",
+          marginBottom: 20,
+          alignItems: "center",
+        }}
+      >
+        <Title level={3} style={{ margin: 0 }}>
+          🎾 Open Matches
+        </Title>
 
-export default UserDashboard
+        <Button
+          type="primary"
+          icon={<ReloadOutlined spin={loadOpenMatches} />}
+          size="large"
+          style={{
+            background: "linear-gradient(135deg, #7CB342 0%, #43A047 100%)",
+            border: "none",
+            borderRadius: 999,
+            fontWeight: 700,
+            paddingInline: 24,
+            boxShadow: "0 6px 16px rgba(67,160,71,.35)",
+            transition: "all .25s ease",
+          }}
+          onMouseEnter={(e) => {
+            e.currentTarget.style.transform = "translateY(-2px)";
+            e.currentTarget.style.boxShadow =
+              "0 10px 24px rgba(67,160,71,.45)";
+          }}
+          onMouseLeave={(e) => {
+            e.currentTarget.style.transform = "translateY(0)";
+            e.currentTarget.style.boxShadow =
+              "0 6px 16px rgba(67,160,71,.35)";
+          }}
+          onClick={() => {
+            fetchOpenMatches();
+          }}
+        >
+          {loadOpenMatches ? "Refreshing..." : "Refresh games"}
+        </Button>
+      </Space>
+
+      <Spin
+        spinning={loadOpenMatches}
+        description="Obtaining matches..."
+        indicator={<TennisLoader />}
+      >
+        <JoinMatch
+          openMatches={openMatch}
+          loading={loadOpenMatches}
+          fetchMatches={fetchOpenMatches}
+        />
+      </Spin>
+
+
+    </>
+  );
+};
+
+export default UserDashboard;

--- a/client/src/pages/matches/MatchVote.jsx
+++ b/client/src/pages/matches/MatchVote.jsx
@@ -1,54 +1,122 @@
-import { Row, Col } from "antd";
+import { useEffect } from "react";
+import {
+  Row,
+  Col,
+  Space,
+  Typography,
+  Button,
+  Spin,
+} from "antd";
+import { ReloadOutlined } from "@ant-design/icons";
+
 import { useAuth } from "../../context";
 import { useMatches } from "../../context/MatchContext";
-import VoteCard from "../../components/matches/VoteCard";
-import EmptyVote from "../../components/matches/EmptyVote";
-import { useEffect } from "react";
 import { useFeedback } from "../../context/FeedbackContext";
 
+import VoteCard from "../../components/matches/VoteCard";
+import EmptyVote from "../../components/matches/EmptyVote";
+import TennisLoader from "../../components/Animations/TennisLoader";
+
+const { Title } = Typography;
+
 const MatchVote = () => {
+  const {
+    matches,
+    loadMatches,
+    fetchMatches,
+  } = useMatches();
 
-    const { matches, loadMatches } = useMatches();
-    const { user } = useAuth();
-    const {triggerFeedbackCheck} = useFeedback();    
+  const { user } = useAuth();
+  const { triggerFeedbackCheck } = useFeedback();
 
-    const voteMatches = matches
-        .filter(m =>
-            m.status === "Played" &&
-            m.players?.some(p => p.user?._id === user._id)
-        )
-        .sort((a, b) => new Date(a.date) - new Date(b.date));    
-    
+  const voteMatches = matches
+    .filter(
+      (m) =>
+        m.status === "Played" &&
+        m.players?.some((p) => p.user?._id === user?._id)
+    )
+    .sort((a, b) => new Date(a.date) - new Date(b.date));
 
-    useEffect(() => {
-        if (voteMatches.length && user){
-            triggerFeedbackCheck(
-                'post_match',
-                {
-                    action: 'match_played',
-                    matchId: voteMatches[0]?._id
-                },
-                'match',
-                'How was your experience on your match?'
-            )
-        }
-    }, [user, voteMatches, triggerFeedbackCheck])
+  useEffect(() => {
+    if (voteMatches.length && user) {
+      triggerFeedbackCheck(
+        "post_match",
+        {
+          action: "match_played",
+          matchId: voteMatches[0]?._id,
+        },
+        "match",
+        "How was your experience on your match?"
+      );
+    }
+  }, [user, voteMatches, triggerFeedbackCheck]);
 
-    if (!voteMatches || voteMatches.length === 0) return <EmptyVote />
+  return (
+    <>
+      <Space
+        style={{
+          width: "100%",
+          justifyContent: "space-between",
+          alignItems: "center",
+          marginBottom: 20,
+        }}
+      >
+        <Title level={3} style={{ margin: 0 }}>
+          ⭐ Match Feedback
+        </Title>
 
-    return (
-        <Row gutter={[16, 16]}>
+        <Button
+          type="primary"
+          icon={<ReloadOutlined spin={loadMatches} />}
+          disabled={loadMatches}
+          onClick={() => fetchMatches()}
+          size="large"
+          style={{
+            background: "linear-gradient(135deg, #7CB342 0%, #43A047 100%)",
+            border: "none",
+            borderRadius: 999,
+            fontWeight: 700,
+            paddingInline: 24,
+            boxShadow: "0 6px 16px rgba(67,160,71,.35)",
+            transition: "all .25s ease",
+          }}
+          onMouseEnter={(e) => {
+            e.currentTarget.style.transform = "translateY(-2px)";
+            e.currentTarget.style.boxShadow =
+              "0 10px 24px rgba(67,160,71,.45)";
+          }}
+          onMouseLeave={(e) => {
+            e.currentTarget.style.transform = "translateY(0)";
+            e.currentTarget.style.boxShadow =
+              "0 6px 16px rgba(67,160,71,.35)";
+          }}
+        >
+          {loadMatches ? "Refreshing..." : "Refresh Matches"}
+        </Button>
+      </Space>
+
+      <Spin
+        spinning={loadMatches}
+        indicator={<TennisLoader />}
+      >
+        {voteMatches.length === 0 ? (
+          <EmptyVote />
+        ) : (
+          <Row gutter={[16, 16]}>
             {voteMatches.map((m) => (
-                <Col key={m._id} lg={12} md={16} sm={24} xs={24}>
-                    <VoteCard
-                        match={m}
-                        loadMatches={loadMatches}
-                        userId={user._id}
-                    />
-                </Col>
+              <Col key={m._id} lg={12} md={16} sm={24} xs={24}>
+                <VoteCard
+                  match={m}
+                  loadMatches={loadMatches}
+                  userId={user._id}
+                />
+              </Col>
             ))}
-        </Row>
-    );
+          </Row>
+        )}
+      </Spin>
+    </>
+  );
 };
 
 export default MatchVote;

--- a/client/src/styles/Loader.css
+++ b/client/src/styles/Loader.css
@@ -1,0 +1,15 @@
+.tennis-loader {
+    font-size: 64px;
+    animation: tennis-spin 1s linear infinite;
+    user-select: none;
+}
+
+@keyframes tennis-spin {
+    from {
+        transform: rotate(0deg);
+    }
+
+    to {
+        transform: rotate(360deg);
+    }
+}

--- a/server/controller/match.js
+++ b/server/controller/match.js
@@ -198,7 +198,7 @@ export const getOpenMatch = async (req, res) => {
     try {
         const matches = await Match.find({
                 status: {
-                  $in: ['Open', 'Full', 'Ready']
+                  $in: ['Open', 'Full', 'Ready', 'Played']
                 }
             })
             .sort({'date': 1})


### PR DESCRIPTION
Introduce TennisLoader component and Loader.css. Integrate loader and refresh controls across AdminDashboard, UserDashboard and MatchVote: add Spin indicators, Reload buttons, and improved loading state handling (useMatches renamed usages like openMatches/loadOpenMatches and batched refresh). Update PendingTransactions/UpComingMatches props accordingly. Server: include 'Played' in getOpenMatch query to return played matches as well.