### PR TITLE
Show leave deadline; update messages

### DIFF
--- a/client/src/components/matches/MatchSummaryTabs.jsx
+++ b/client/src/components/matches/MatchSummaryTabs.jsx
@@ -28,6 +28,9 @@ const MatchSummaryTabs = ({
     onLeave
 }) => {
 
+
+
+
     const { Text, Title, Link } = Typography;
     const { user } = useAuth();
     const navigate = useNavigate();
@@ -109,6 +112,12 @@ const MatchSummaryTabs = ({
 
     const disabledLeave = isJoinedPlayer && isLess24h;
 
+
+    const leaveDeadline = dayjs(date)
+        .hour(Number(startTime.split(":")[0]))
+        .minute(Number(startTime.split(":")[1]))
+        .subtract(24, "hour");
+
     if (!user?._id) return null;
 
     return (
@@ -119,6 +128,12 @@ const MatchSummaryTabs = ({
                 </Title>
                 <Text type="secondary">
                     <ClockCircleOutlined /> {startTime} - {endTime}
+                </Text>
+
+                <br />
+
+                <Text type="danger" style={{ fontSize: 12 }}>
+                    <small>Deadline: {leaveDeadline.format("ddd DD MMM, HH:mm")}</small>
                 </Text>
             </div>
 

--- a/client/src/components/modals/WhatsappMessage.jsx
+++ b/client/src/components/modals/WhatsappMessage.jsx
@@ -51,6 +51,9 @@ const WhatsappMessage = ({ open, setOpenMessage, match }) => {
 
         const message = `🎾 Tennis Doubles Game 🎾
 
+Only for visibility please join using the link
+https://weekly-tennis-match.vercel.app/games
+
 DEADLINE: ${deadline.format("H[h]")} - ${deadline.format("dddd, MMM D, YYYY")}
 Date:  ${matchDateTime.format("dddd, MMM D, YYYY HH[h]")}
 Location: ${match.location.name} - ${match.location.address}

--- a/client/src/components/utils/NTRPLevel.jsx
+++ b/client/src/components/utils/NTRPLevel.jsx
@@ -47,7 +47,7 @@ const NTRPLevel = () => {
                     </a>
  
                         <Link onClick={() => setopenChart(true)}>
-                            Hover to see NTRP Chart
+                            Click to see NTRP Chart
                         </Link>                   
                 </Flex>
             </div>


### PR DESCRIPTION
Display the 24h leave deadline in match summary (MatchSummaryTabs.jsx) by computing leaveDeadline from match date and startTime and showing a formatted deadline. Add a visibility/join link to the WhatsApp share template (WhatsappMessage.jsx). Update NTRPLevel link text from "Hover to see NTRP Chart" to "Click to see NTRP Chart" to reflect interaction.