### PR TITLE
Increase MatchDetails column width on lg

### DIFF
--- a/client/src/components/matches/MatchPlayers.jsx
+++ b/client/src/components/matches/MatchPlayers.jsx
@@ -137,7 +137,7 @@ const MatchPlayers = () => {
       {isReady ? (
         <Row gutter={[24, 24]}>
           {match.generatedMatches.map((m, index) => (
-            <Col key={index} xs={24} sm={12} lg={6}>
+            <Col key={index} xs={24} sm={12} lg={12}>
               <MatchDetails match={m} />
             </Col>
           ))}


### PR DESCRIPTION
Update MatchPlayers.jsx: change Col lg prop from 6 to 12 so MatchDetails spans half the row on large screens (two per row) instead of a quarter (four per row), improving readability of match cards.