### PR TITLE
Add FCM push notifications (client & server)

### DIFF
--- a/client/public/firebase-messaging-sw.js
+++ b/client/public/firebase-messaging-sw.js
@@ -1,0 +1,13 @@
+importScripts("https://www.gstatic.com/firebasejs/12.1.0/firebase-app-compat.js");
+importScripts("https://www.gstatic.com/firebasejs/12.1.0/firebase-messaging-compat.js");
+
+firebase.initializeApp({
+  apiKey: "AIzaSyCzwHMUK1pIfBk8TlDcjiN3yDmIy3sSOqc",
+  authDomain: "weeklytennis.firebaseapp.com",
+  projectId: "weeklytennis",
+  storageBucket: "weeklytennis.firebasestorage.app",
+  messagingSenderId: "874939629338",
+  appId: "1:874939629338:web:63eb44ea4a42ea21b8f6a3"
+});
+
+const messaging = firebase.messaging();

--- a/client/src/actions/auth.js
+++ b/client/src/actions/auth.js
@@ -9,6 +9,15 @@ export const login = async (values) => {
 
 }
 
+export const getNotificationToken = async(token) =>{
+    const data = await axiosInstance.post('/notification/token', {token})
+
+    console.log(data)
+
+    return data
+
+}
+
 export const checkEmailValidity = async(email) =>{
     const {data} = await axiosInstance.get('/user/validate', {
         params: {email}

--- a/client/src/config/firebase.js
+++ b/client/src/config/firebase.js
@@ -1,6 +1,7 @@
 
 import { initializeApp } from "firebase/app";
 import { getAuth, GoogleAuthProvider } from "firebase/auth";
+import { getMessaging } from "firebase/messaging";
 
 const firebaseConfig = {
   apiKey: process.env.REACT_APP_FIREBASE_KEY,
@@ -20,3 +21,7 @@ export const googleProvider = new GoogleAuthProvider();
 googleProvider.setCustomParameters({
   prompt: "select_account",
 });
+
+export const messaging = getMessaging(app);
+
+

--- a/client/src/context/AuthContext.jsx
+++ b/client/src/context/AuthContext.jsx
@@ -1,5 +1,8 @@
 import { useContext, useState, createContext, useEffect } from "react";
-import { getUserAuth } from "../actions/auth";
+import { getNotificationToken, getUserAuth } from "../actions/auth";
+import { getToken } from "firebase/messaging";
+//import { toast } from "react-toastify";
+import { messaging } from "../config/firebase";
 
 export const AuthContext = createContext();
 
@@ -46,6 +49,32 @@ export const AuthProvider = ({ children }) => {
 
     }, []);
 
+
+
+    useEffect(() => {
+        if (!user) return;
+
+        const regsiterFCM = async () => {
+            try {
+
+                const token = await getToken(messaging, {
+                    vapidKey: process.env.REACT_APP_FIREBASE_VAPID_KEY
+                })
+
+                const response = await getNotificationToken(token)
+
+                console.log(response)
+
+            } catch (error) {
+                console.log(error)
+                //toast.error('Error generating FCM token')
+            }
+        }
+
+        regsiterFCM()
+
+    }, [user])
+
     // login / refresh session
     const setSession = async (token) => {
 
@@ -61,8 +90,9 @@ export const AuthProvider = ({ children }) => {
 
         localStorage.removeItem("token");
         setUser(null);
-
     };
+
+
 
     return (
         <AuthContext.Provider

--- a/client/src/pages/dashboard/UserDashboard.jsx
+++ b/client/src/pages/dashboard/UserDashboard.jsx
@@ -16,6 +16,8 @@ const UserDashboard = () => {
     (match) => match.status !== "Played"
   );
 
+
+
   return (
     <>
       <Space
@@ -72,8 +74,6 @@ const UserDashboard = () => {
           fetchMatches={fetchOpenMatches}
         />
       </Spin>
-
-
     </>
   );
 };

--- a/server/config/firebase.js
+++ b/server/config/firebase.js
@@ -1,12 +1,18 @@
-// import admin from 'firebase-admin';
-// import {createRequire} from 'module';
+import admin from "firebase-admin";
+import serviceAccount from '../weeklytennis-firebase-adminsdk-fbsvc-240ec5aa4c.json' with { type: "json" }
+import dotenv from 'dotenv'
 
-// const require  = createRequire(import.meta.url);
+dotenv.config();
 
-// const serviceAccount = require('../weeklytennis-firebase-adminsdk-fbsvc-a7b8b3d1d8.json')
 
-// admin.initializeApp({
-//     credential: admin.credential.cert(serviceAccount)
-// });
+admin.initializeApp({
+  credential: admin.credential.cert({
+    projectId: process.env.FIREBASE_PROJECT_ID,
+    clientEmail: process.env.FIREBASE_CLIENT_EMAIL,
+    privateKey: process.env.FIREBASE_PRIVATE_KEY//.replace(/\\n/g, "\n")
+  }),
+});
 
-// export default admin;
+
+
+export default admin;

--- a/server/controller/match.js
+++ b/server/controller/match.js
@@ -17,6 +17,7 @@ import {
 } from '../utils/backups.js';
 import jwt from 'jsonwebtoken';
 import mongoose from 'mongoose';
+import { sendNewMatchNotification, sendNotification } from '../services/notificationService.js';
 
 
 
@@ -92,6 +93,19 @@ export const newMatch = async (req, res) => {
             maxPlayers,
             paymentMethods: finalPaymentMethods
         });
+
+        /* PUSH NOTIFICATION */   
+        const usersNotice = await User.find({
+          isActive:true,
+          fcmToken: {
+            $exists: true,
+            $ne: null
+          }
+        }).select("fcmToken");
+
+        const tokens = usersNotice.map(user => user.fcmToken).filter(Boolean);
+
+        await sendNewMatchNotification(tokens, location.name)
 
         return res.status(201).json(match);
 

--- a/server/controller/notification.js
+++ b/server/controller/notification.js
@@ -1,0 +1,22 @@
+import admin from "../config/firebase.js"
+import User from "../models/user.js";
+
+
+export const saveFCMToken = async(req, res) =>{
+
+    try {
+        await User.findByIdAndUpdate(req.user._id, {
+            fcmToken: req.body.token
+        }) ;
+
+        return res.status(200).json({
+            ok: true
+        })
+    } catch (error) {
+        console.log(error)
+        return res.status(500).json({
+            ok: false,
+            message: 'Internal error obtaining message token'
+        })
+    }
+}

--- a/server/models/user.js
+++ b/server/models/user.js
@@ -180,6 +180,10 @@
         lastAppFeedback:{
             type: Date,
             default: null 
+        },
+        fcmToken: {
+            type: String,
+            default: null
         }
     }, {
         timestamps: true

--- a/server/routes/notification.js
+++ b/server/routes/notification.js
@@ -1,0 +1,19 @@
+
+import {Router} from 'express';
+import { protect, verifyAdmin, verifyBookerOrAdmin } from '../middlewares/auth.js';
+import { acceptInvite, addMatchCourts, 
+declineInvite, generateMatches, getAllMatches,
+getMatch, getOpenMatch, joinMatch, 
+leaveMatch, newMatch, removeMatchCourts,
+updateGeneratedMatches,
+updateMatch, updateMatchStatus } from '../controller/match.js';
+import { createMatchValidator } from '../validator/matchCreateValidator.js';
+import { validateFields, validateObjectId } from '../middlewares/validateFields.js';
+import { matchLimiter, readLimiter, viewMatchesLimiter, writeLimiter } from '../config/expressLimit.js';
+import { saveFCMToken } from '../controller/notification.js';
+
+const router = Router();
+
+router.post('/token', protect, saveFCMToken)
+
+export default router;

--- a/server/server.js
+++ b/server/server.js
@@ -14,6 +14,7 @@ import skillRoutes from './routes/skill.js';
 import adminRoutes from './routes/admin.js';
 import walletRoutes from './routes/wallet.js';
 import feedbackRoutes from './routes/feedback.js'
+import notificationRoutes from './routes/notification.js'
 import './jobs/matchStatus.js'
 import { globalLimiter } from './config/expressLimit.js';
 import helmet from 'helmet'
@@ -63,6 +64,7 @@ app.use('/api/profile', profileRoutes)
 app.use('/api/vote', skillRoutes)
 app.use('/api/wallet', walletRoutes)
 app.use('/api/feedback', feedbackRoutes)
+app.use('/api/notification', notificationRoutes)
 
 //Conexión
 const PORT = process.env.PORT || 7000;

--- a/server/services/notificationService.js
+++ b/server/services/notificationService.js
@@ -1,0 +1,38 @@
+import admin from "../config/firebase.js";
+
+export const sendNotification = async(tokens, title, body, data) =>{
+    if(!tokens?.length) return;
+
+    try {
+        const message = {
+            notification: {
+                title,
+                body
+            },
+            data,
+            tokens
+        }
+
+        const response = await admin.messaging().sendEachForMulticast(message)
+
+        console.log(
+            `Notifications: ${response.successCount} sent, ${response.failureCount} failed`
+        );
+
+        return response;
+    } catch (error) {
+        console.log(error)
+    }
+}
+
+
+export const sendNewMatchNotification = async (tokens, locationName) => {
+    return sendNotification(
+        tokens,
+        "🎾 New Match Available",
+        `A new match has been created at ${locationName}.`,
+        {
+            type: "NEW_MATCH"
+        }
+    );
+};


### PR DESCRIPTION
Integrate Firebase Cloud Messaging end-to-end. Client: add service worker (firebase-messaging-sw.js), initialize messaging in firebase config, obtain FCM token in AuthContext and POST it to /api/notification/token via new getNotificationToken action. Server: initialize Firebase Admin with env-based credentials, add fcmToken field to User model, create notification controller, route, and notificationService to send multicast messages. Trigger new-match notifications when a match is created. Includes minor UI whitespace fixes.