### PR TITLE
Remove debug log and fix Firebase private key

### DIFF
--- a/client/src/context/AuthContext.jsx
+++ b/client/src/context/AuthContext.jsx
@@ -63,7 +63,7 @@ export const AuthProvider = ({ children }) => {
 
                 const response = await getNotificationToken(token)
 
-                console.log(response)
+                //console.log(response)
 
             } catch (error) {
                 console.log(error)

--- a/server/config/firebase.js
+++ b/server/config/firebase.js
@@ -4,12 +4,14 @@ import dotenv from 'dotenv'
 
 dotenv.config();
 
+const privateKey = process.env.FIREBASE_PRIVATE_KEY.replace(/\\n/g, '\n');
+
 
 admin.initializeApp({
   credential: admin.credential.cert({
     projectId: process.env.FIREBASE_PROJECT_ID,
     clientEmail: process.env.FIREBASE_CLIENT_EMAIL,
-    privateKey: process.env.FIREBASE_PRIVATE_KEY//.replace(/\\n/g, "\n")
+    privateKey: privateKey//.replace(/\\n/g, "\n")
   }),
 });
 


### PR DESCRIPTION
Comment out a noisy debug console.log in AuthContext. Fix Firebase admin initialization to correctly load a multiline private key from FIREBASE_PRIVATE_KEY by replacing escaped \n sequences with real newlines before passing it to admin.credential.cert(). Prevents credential parsing errors when the key is stored in environment variables.