### PR TITLE
Notify users when a player joins a match

### DIFF
--- a/server/controller/match.js
+++ b/server/controller/match.js
@@ -99,6 +99,7 @@ export const newMatch = async (req, res) => {
           isActive:true,
           fcmToken: {
             $exists: true,
+            _id: { $ne: userId },
             $ne: null
           }
         }).select("fcmToken");
@@ -514,10 +515,23 @@ export const joinMatch = async (req, res) => {
 
       await session.commitTransaction();
 
+      /* Push notification */
+      const usersNotice = await User.find({
+        isActive: true,
+        _id: { $ne: userId },
+        fcmToken: { $exists: true, $ne: null }
+      }).select("fcmToken");
+
+      const tokens = usersNotice.map(u => u.fcmToken).filter(Boolean);
+
+      if (tokens.length > 0) {
+        await sendJoinMatchNotification(tokens, user.name);
+      }
+
       return res.status(200).json({
         role: "player",
         match: updatedMatch
-      });
+      });    
     }
 
     /* ===================================================== */

--- a/server/services/notificationService.js
+++ b/server/services/notificationService.js
@@ -36,3 +36,15 @@ export const sendNewMatchNotification = async (tokens, locationName) => {
         }
     );
 };
+
+
+export const sendJoinMatchNotification = async (tokens, playerName, locationName) => {
+    return sendNotification(
+        tokens,
+        "🎾 New Player Joined",
+        `${playerName} just joined your match at ${locationName}.`,
+        {
+            type: "PLAYER_JOINED"
+        }
+    );
+};


### PR DESCRIPTION
Add server-side push notifications for the join-match flow. After a user joins a match, query active users (excluding the acting user) with FCM tokens, collect tokens and call sendJoinMatchNotification. Added sendJoinMatchNotification helper in notificationService to format and send a "player joined" notification. Also adjusted the newMatch FCM user query to exclude the creating user when selecting tokens.