### PR TITLE
Extract join notification to service

### DIFF
--- a/server/controller/match.js
+++ b/server/controller/match.js
@@ -17,7 +17,7 @@ import {
 } from '../utils/backups.js';
 import jwt from 'jsonwebtoken';
 import mongoose from 'mongoose';
-import { sendNewMatchNotification, sendNotification } from '../services/notificationService.js';
+import { notifyOtherPlayersOfJoin, sendJoinMatchNotification, sendNewMatchNotification, sendNotification } from '../services/notificationService.js';
 
 
 
@@ -513,20 +513,13 @@ export const joinMatch = async (req, res) => {
         await updatedMatch.save({ session });
       }
 
-      await session.commitTransaction();
+      await session.commitTransaction(); 
 
-      /* Push notification */
-      const usersNotice = await User.find({
-        isActive: true,
-        _id: { $ne: userId },
-        fcmToken: { $exists: true, $ne: null }
-      }).select("fcmToken");
-
-      const tokens = usersNotice.map(u => u.fcmToken).filter(Boolean);
-
-      if (tokens.length > 0) {
-        await sendJoinMatchNotification(tokens, user.name);
-      }
+      try {
+        await notifyOtherPlayersOfJoin(userId, user.name);
+      } catch (notifError) {
+        console.error("Error sending join notification:", notifError);
+}
 
       return res.status(200).json({
         role: "player",
@@ -572,6 +565,13 @@ export const joinMatch = async (req, res) => {
       }
 
       await session.commitTransaction();
+
+
+      try {
+        await notifyOtherPlayersOfJoin(userId, user.name);
+      } catch (notifError) {
+        console.error("Error sending join notification:", notifError);
+}
 
       return res.status(200).json({
         role: "player",

--- a/server/services/notificationService.js
+++ b/server/services/notificationService.js
@@ -1,4 +1,20 @@
 import admin from "../config/firebase.js";
+import User from '../models/user.js'
+
+
+export const notifyOtherPlayersOfJoin = async (userId, playerName) => {
+  const usersNotice = await User.find({
+    isActive: true,
+    _id: { $ne: userId },
+    fcmToken: { $exists: true, $ne: null }
+  }).select("fcmToken");
+
+  const tokens = usersNotice.map(u => u.fcmToken).filter(Boolean);
+
+  if (tokens.length > 0) {
+    await sendJoinMatchNotification(tokens, playerName);
+  }
+};
 
 export const sendNotification = async(tokens, title, body, data) =>{
     if(!tokens?.length) return;


### PR DESCRIPTION
Move the logic that finds other players' FCM tokens and sends a "player joined" notification into a new notifyOtherPlayersOfJoin helper in server/services/notificationService.js. Update server/controller/match.js to call the new helper (with try/catch) instead of performing the DB query and send inline, so notification errors are logged and won't break the join response. Also import the User model in the notification service and export the new function.