### PR TITLE
Include match location in join notifications

### DIFF
--- a/server/controller/match.js
+++ b/server/controller/match.js
@@ -17,7 +17,7 @@ import {
 } from '../utils/backups.js';
 import jwt from 'jsonwebtoken';
 import mongoose from 'mongoose';
-import { notifyOtherPlayersOfJoin, sendJoinMatchNotification, sendNewMatchNotification, sendNotification } from '../services/notificationService.js';
+import { notifyOtherPlayersOfJoin, sendNewMatchNotification, sendNotification } from '../services/notificationService.js';
 
 
 
@@ -434,7 +434,8 @@ export const joinMatch = async (req, res) => {
       throw new Error("Payment method required");
     }
 
-    const match = await Match.findById(id).session(session);
+    const match = await Match.findById(id).session(session).populate('location', 'name')
+
 
     if (!match) {
       throw new Error("Match does not exist");
@@ -516,7 +517,7 @@ export const joinMatch = async (req, res) => {
       await session.commitTransaction(); 
 
       try {
-        await notifyOtherPlayersOfJoin(userId, user.name);
+        await notifyOtherPlayersOfJoin(userId, user.name, match.location.name);
       } catch (notifError) {
         console.error("Error sending join notification:", notifError);
 }
@@ -568,7 +569,7 @@ export const joinMatch = async (req, res) => {
 
 
       try {
-        await notifyOtherPlayersOfJoin(userId, user.name);
+        await notifyOtherPlayersOfJoin(userId, user.name, match.location.name);
       } catch (notifError) {
         console.error("Error sending join notification:", notifError);
 }

--- a/server/services/notificationService.js
+++ b/server/services/notificationService.js
@@ -2,7 +2,7 @@ import admin from "../config/firebase.js";
 import User from '../models/user.js'
 
 
-export const notifyOtherPlayersOfJoin = async (userId, playerName) => {
+export const notifyOtherPlayersOfJoin = async (userId, playerName, location) => {
   const usersNotice = await User.find({
     isActive: true,
     _id: { $ne: userId },
@@ -12,7 +12,7 @@ export const notifyOtherPlayersOfJoin = async (userId, playerName) => {
   const tokens = usersNotice.map(u => u.fcmToken).filter(Boolean);
 
   if (tokens.length > 0) {
-    await sendJoinMatchNotification(tokens, playerName);
+    await sendJoinMatchNotification(tokens, playerName, location);
   }
 };
 


### PR DESCRIPTION
Populate match location in joinMatch and pass location.name to notifyOtherPlayersOfJoin so join notifications include the venue. Updated notifyOtherPlayersOfJoin signature and forwarded the location to sendJoinMatchNotification. Also removed an unused import in the controller. This makes join alerts more informative by including the match location.