### PR TITLE
Handle numeric price/balance and wallet UI

### DIFF
--- a/client/src/components/matches/PaymentModal.jsx
+++ b/client/src/components/matches/PaymentModal.jsx
@@ -25,7 +25,10 @@ const PaymentModal = ({
         new Intl.NumberFormat("es-ES", {
             style: "currency",
             currency: "EUR",
-        }).format(value || 0);
+        }).format(Number(value) || 0);
+
+    const numericPrice = Number(price);
+    const numericBalance = Number(balance) || 0;
 
     return (
         <Modal
@@ -41,7 +44,7 @@ const PaymentModal = ({
             destroyOnHidden
         >
             <p style={{ marginBottom: 16 }}>
-                Price per player <strong>{formatEUR(price)}</strong>
+                Price per player <strong>{formatEUR(numericPrice)}</strong>
             </p>
 
             <Radio.Group
@@ -49,24 +52,33 @@ const PaymentModal = ({
                 value={selectedPayment}
                 style={{ width: "100%" }}
             >
-                <Space orientation="vertical" style={{ width: "100%" }} size="middle">
+                <Space
+                    direction="vertical"
+                    style={{ width: "100%" }}
+                    size="middle"
+                >
                     {paymentMethods.map((pm) => {
 
                         const isWallet = pm.type === "wallet";
-                        const isDisabled = isWallet && balance <= 0;
+                        const isDisabled =
+                            isWallet && numericBalance < numericPrice;
 
                         return (
                             <Card
                                 key={pm.type}
                                 hoverable={!isDisabled}
-                                onClick={() => !isDisabled && setSelectedPayment(pm.type)}
+                                onClick={() =>
+                                    !isDisabled && setSelectedPayment(pm.type)
+                                }
                                 style={{
                                     border:
                                         selectedPayment === pm.type
                                             ? "2px solid #1677ff"
                                             : "1px solid #f0f0f0",
                                     borderRadius: 8,
-                                    cursor: isDisabled ? "not-allowed" : "pointer",
+                                    cursor: isDisabled
+                                        ? "not-allowed"
+                                        : "pointer",
                                     opacity: isDisabled ? 0.5 : 1,
                                     transition: "all 0.2s ease"
                                 }}
@@ -81,15 +93,16 @@ const PaymentModal = ({
 
                                     <Text type="secondary">
                                         {isWallet
-                                            ? formatEUR(balance)
+                                            ? `${formatEUR(numericBalance)} available`
                                             : pm.value}
                                     </Text>
 
-                                    {isWallet && balance <= 0 && (
+                                    {isWallet && isDisabled && (
                                         <>
                                             <br />
                                             <Text type="danger">
-                                                Insufficient balance
+                                                Insufficient balance (requires{" "}
+                                                {formatEUR(numericPrice)})
                                             </Text>
                                         </>
                                     )}


### PR DESCRIPTION
Cast price/balance to numbers (formatEUR uses Number(value)) and add numericPrice/numericBalance. Use numeric values for display and to disable wallet payments when balance < price. Update card text to show "X available" for wallet and include required amount in the "Insufficient balance" message. Small JSX/formatting cleanup (spacing, cursor/opacity handling).