### PR TITLE
Add responsive mobile tables; fix match notification filter

### DIFF
--- a/client/src/pages/matches/MatchesTable.jsx
+++ b/client/src/pages/matches/MatchesTable.jsx
@@ -7,6 +7,7 @@ import {
     Tag,
     Tooltip,
     Typography,
+    Grid,
 } from "antd";
 import { useMatches } from "../../context/MatchContext";
 import dayjs from "dayjs";
@@ -14,12 +15,12 @@ import {
     generateMatch,
     removeMatchCourt,
     updateStatus,
-    addMatchCourts, 
+    addMatchCourts,
 } from "../../actions/matches";
 import { toast } from "react-toastify";
 import colors from "../../themes/colors";
 import { adminRemovePlayer } from "../../actions/admin";
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import AddNewCourtsModal from "../../components/matches/AddNewCourtsModal";
 import { surfaceColors } from "../../themes/surfaceColors";
 import WhatsappMessage from "../../components/modals/WhatsappMessage";
@@ -30,9 +31,22 @@ const MatchesTable = () => {
     const { matches, fetchMatches, loadMatches } = useMatches();
     const { Timer } = Statistic;
 
+    const { useBreakpoint } = Grid;
+    const screens = useBreakpoint();
+
     const [isModalOpen, setIsModalOpen] = useState(false);
     const [selectedMatch, setSelectedMatch] = useState(null);
     const [openMessageModal, setOpenMessageModal] = useState(false)
+
+    // Orden por defecto: más reciente primero. El sorter de la columna
+    // "Date" en desktop sigue funcionando igual (permite alternar asc/desc),
+    // esto solo define el orden inicial, necesario porque en mobile no
+    // existe la columna "Date" de la que depende defaultSortOrder.
+    const sortedMatches = useMemo(() => {
+        return [...matches].sort(
+            (a, b) => dayjs(b.date).valueOf() - dayjs(a.date).valueOf()
+        );
+    }, [matches]);
 
     const statusOptions = [
         { value: "Open", label: "Open" },
@@ -105,7 +119,7 @@ const MatchesTable = () => {
             const {message} = await addMatchCourts(courts, selectedMatch?._id)
 
             toast.success(message)
-            
+
             setIsModalOpen(false);
             setSelectedMatch(null);
             fetchMatches();
@@ -137,10 +151,10 @@ const MatchesTable = () => {
 };
 
     /* -------------------------------------------------- */
-    /* TABLE COLUMNS                                      */
+    /* DESKTOP COLUMNS (comportamiento original, sin cambios de lógica) */
     /* -------------------------------------------------- */
 
-    const columns = [
+    const desktopColumns = [
         {
             title: "Date",
             key: "date",
@@ -172,14 +186,17 @@ const MatchesTable = () => {
         },
         {
             title: "Time",
+            key: "time",
             render: (m) => `${m.startTime} - ${m.endTime}`,
         },
         {
             title: "Location",
+            key: "location",
             render: (_, m) => m?.location?.name,
         },
         {
             title: "Status",
+            key: "status",
             render: (m) =>
                 m.status === "Played" || m.status === "Closed" ? (
                     <Tag color={statusColors[m.status]}>{m.status}</Tag>
@@ -194,6 +211,7 @@ const MatchesTable = () => {
         },
         {
             title: "Courts",
+            key: "courts",
             render: (_, r) => (
                 <Flex gap="small" align="center" wrap>
                     {r.courts.map((cn) => (
@@ -212,7 +230,7 @@ const MatchesTable = () => {
                             <Tag
                                 color="cyan"
                                 style={{ cursor: "pointer", borderStyle: "dashed" }}
-                                onClick={() => openAddCourts(r)} // ✅ AQUÍ
+                                onClick={() => openAddCourts(r)}
                             >
                                 + Add Courts
                             </Tag>
@@ -223,6 +241,7 @@ const MatchesTable = () => {
         },
         {
             title: "Players",
+            key: "players",
             render: (_, r) => (
                 <Flex gap="small" wrap>
                     {r.players.map((p) => (
@@ -232,7 +251,7 @@ const MatchesTable = () => {
                             closable={r.status !== "Played" && r.status !== "Full"}
                             onClose={() => handleRemovePlayer(r._id, p.user._id)}
                         >
-                            {p.user.name} {p.user.lastname} 
+                            {p.user.name} {p.user.lastname}
                         </Tag>
                     ))}
                 </Flex>
@@ -240,6 +259,7 @@ const MatchesTable = () => {
         },
         {
             title: "Generate Match",
+            key: "generateMatch",
             render: (r) =>
                 (r.status === "Open" || r.status === "Full") &&
                 r.players.length >= 4 && (
@@ -253,6 +273,7 @@ const MatchesTable = () => {
         },
         {
             title: "Generate whatsapp message",
+            key: "generateMessage",
             render: (r) =>
                 (r.status === "Open" || r.status === "Full") &&
                 (
@@ -269,6 +290,137 @@ const MatchesTable = () => {
         },
     ];
 
+    /* -------------------------------------------------- */
+    /* MOBILE COLUMNS: una sola columna "card" que agrupa todo   */
+    /* Prioriza Generate match / Generate message arriba          */
+    /* -------------------------------------------------- */
+
+    const mobileColumns = [
+        {
+            title: "Match",
+            key: "match-mobile",
+            render: (r) => {
+                const canGenerateMatch =
+                    (r.status === "Open" || r.status === "Full") &&
+                    r.players.length >= 4;
+
+                const canGenerateMessage =
+                    r.status === "Open" || r.status === "Full";
+
+                return (
+                    <Flex vertical gap={10} style={{ width: "100%" }}>
+                        {/* Header: fecha + hora + status */}
+                        <Flex justify="space-between" align="center" wrap="wrap" gap={8}>
+                            <Flex vertical gap={0}>
+                                <span style={{ fontWeight: 600 }}>
+                                    {dayjs(r.date).format("DD/MM/YYYY")}
+                                </span>
+                                <Text type="secondary" style={{ fontSize: 12 }}>
+                                    {r.startTime} - {r.endTime}
+                                </Text>
+                            </Flex>
+
+                            {r.status === "Played" || r.status === "Closed" ? (
+                                <Tag color={statusColors[r.status]}>{r.status}</Tag>
+                            ) : (
+                                <Select
+                                    size="small"
+                                    value={r.status}
+                                    options={statusOptions}
+                                    onChange={(status) => handleStatusChange(r._id, status)}
+                                    style={{ minWidth: 100 }}
+                                />
+                            )}
+                        </Flex>
+
+                        {/* Location */}
+                        <Text type="secondary" style={{ fontSize: 12 }}>
+                            📍 {r?.location?.name}
+                        </Text>
+
+                        {/* Acciones cruciales: generate match / message */}
+                        {(canGenerateMatch || canGenerateMessage) && (
+                            <Flex gap={8} wrap="wrap">
+                                {canGenerateMatch && (
+                                    <Button
+                                        block
+                                        style={{ backgroundColor: colors.yellow }}
+                                        onClick={() => handleGenerateMatch(r._id)}
+                                    >
+                                        Generate match
+                                    </Button>
+                                )}
+
+                                {canGenerateMessage && (
+                                    <Button
+                                        block
+                                        style={{ backgroundColor: colors.blue }}
+                                        onClick={() => {
+                                            setOpenMessageModal(true);
+                                            setSelectedMatch(r);
+                                        }}
+                                    >
+                                        Generate message
+                                    </Button>
+                                )}
+                            </Flex>
+                        )}
+
+                        {/* Courts */}
+                        <Flex vertical gap={4}>
+                            <Text type="secondary" style={{ fontSize: 12, fontWeight: 600 }}>
+                                Courts
+                            </Text>
+                            <Flex gap="small" align="center" wrap>
+                                {r.courts.map((cn) => (
+                                    <Tag
+                                        key={cn.courtNumber}
+                                        color={surfaceColors[cn?.surface]}
+                                        closable={r.status === "Open"}
+                                        onClose={() => handleRemoveCourt(r._id, cn.courtNumber)}
+                                    >
+                                        Court {cn.courtNumber}
+                                    </Tag>
+                                ))}
+
+                                {(r.status === "Open" || r.status === "Full") && (
+                                    <Tag
+                                        color="cyan"
+                                        style={{ cursor: "pointer", borderStyle: "dashed" }}
+                                        onClick={() => openAddCourts(r)}
+                                    >
+                                        + Add Courts
+                                    </Tag>
+                                )}
+                            </Flex>
+                        </Flex>
+
+                        {/* Players */}
+                        <Flex vertical gap={4}>
+                            <Text type="secondary" style={{ fontSize: 12, fontWeight: 600 }}>
+                                Players ({r.players.length})
+                            </Text>
+                            <Flex gap="small" wrap>
+                                {r.players.map((p) => (
+                                    <Tag
+                                        key={p._id}
+                                        color="green"
+                                        closable={r.status !== "Played" && r.status !== "Full"}
+                                        onClose={() => handleRemovePlayer(r._id, p.user._id)}
+                                    >
+                                        {p.user.name} {p.user.lastname}
+                                    </Tag>
+                                ))}
+                            </Flex>
+                        </Flex>
+                    </Flex>
+                );
+            },
+        },
+    ];
+
+    const columns = screens.xs ? mobileColumns : desktopColumns;
+
     const { Title, Text } = Typography;
 
     return (
@@ -276,14 +428,16 @@ const MatchesTable = () => {
             <Title level={3}>All matches</Title>
             <Text type="secondary">View all matches and manage status</Text>
 
-            <ExportToExcel fileName="matches.xlsx" data={flattenMatchesForExcel(matches)} />
+            <ExportToExcel fileName="matches.xlsx" data={flattenMatchesForExcel(sortedMatches)} />
 
             <Table
                 columns={columns}
-                dataSource={matches}
+                dataSource={sortedMatches}
                 rowKey="_id"
                 loading={loadMatches}
-                scroll={{x: "max-content"}}
+                scroll={screens.xs ? undefined : { x: "max-content" }}
+                showHeader={!screens.xs}
+                tableLayout={screens.xs ? "fixed" : "auto"}
             />
 
             {/* ✅ MODAL */}
@@ -297,7 +451,7 @@ const MatchesTable = () => {
                 onConfirm={handleAddCourts}
             />
 
-            <WhatsappMessage 
+            <WhatsappMessage
                 open={openMessageModal}
                 match={selectedMatch}
                 setOpenMessage={setOpenMessageModal}

--- a/client/src/pages/players/PlayersTable.jsx
+++ b/client/src/pages/players/PlayersTable.jsx
@@ -25,7 +25,7 @@ const PlayersTable = ({ players, loading, fetchPlayers }) => {
 
     const { countries } = useCountries();
 
-   
+
     const [selectedPlayer, setSelectedPlayer] = useState(null);
     const { Text } = Typography;
     const navigate = useNavigate();
@@ -77,19 +77,20 @@ const PlayersTable = ({ players, loading, fetchPlayers }) => {
         }
     };
 
-    const columns = [
+    // ------------------------------------------------------------------
+    // DESKTOP COLUMNS (comportamiento original, sin cambios de lógica)
+    // ------------------------------------------------------------------
+    const desktopColumns = [
         {
             title: "Player name",
             key: "name",
             render: (p) => (
                 <Flex
-                    vertical={screens.xs} // 🔥 clave mobile
-                    align={screens.xs ? "stretch" : "center"}
+                    align="center"
                     justify="space-between"
                     gap={8}
                     style={{ width: "100%" }}
                 >
-                    {/* LEFT SIDE */}
                     <Tooltip title="Click on player to view profile">
                         <Flex
                             align="center"
@@ -97,7 +98,7 @@ const PlayersTable = ({ players, loading, fetchPlayers }) => {
                             style={{
                                 minWidth: 0,
                                 overflow: "hidden",
-                                flex: screens.xs ? "unset" : 1,
+                                flex: 1,
                                 cursor: "pointer"
                             }}
                             onClick={(e) => {
@@ -115,7 +116,7 @@ const PlayersTable = ({ players, loading, fetchPlayers }) => {
                             <span
                                 style={{
                                     fontWeight: 500,
-                                    whiteSpace: screens.xs ? "normal" : "nowrap",
+                                    whiteSpace: "nowrap",
                                     overflow: "hidden",
                                     textOverflow: "ellipsis"
                                 }}
@@ -125,17 +126,15 @@ const PlayersTable = ({ players, loading, fetchPlayers }) => {
                         </Flex>
                     </Tooltip>
 
-                    {/* RIGHT SIDE */}
                     <Button
-                        type={screens.xs ? "primary" : "text"}
+                        type="text"
                         size="small"
-                        block={screens.xs}
                         onClick={(e) => {
                             e.stopPropagation();
                             navigate(`/admin/player/${p._id}`);
                         }}
                     >
-                        {screens.xs ? "View profile" : "View"}
+                        View
                     </Button>
                 </Flex>
             ),
@@ -166,16 +165,11 @@ const PlayersTable = ({ players, loading, fetchPlayers }) => {
             title: "Country",
             key: "country",
             render: (p) => (
-                <Flex
-                    justify="space-between"
-                    align="center"
-                    gap="small"
-                    vertical={screens.xs}
-                >
+                <Flex justify="space-between" align="center" gap="small">
                     <span>{p?.country}</span>
                     <Image
                         preview={false}
-                        width={screens.xs ? 18 : 25}
+                        width={25}
                         alt={`${p?.country} flag`}
                         src={p?.countryFlag}
                     />
@@ -186,18 +180,12 @@ const PlayersTable = ({ players, loading, fetchPlayers }) => {
             title: "NTRP Level",
             key: "ntrplvl",
             render: (p) => (
-                <Flex
-                    justify="center"
-                    align="center"
-                    gap="middle"
-                    vertical={screens.xs}
-                >
+                <Flex justify="center" align="center" gap="middle">
                     <span>{p?.ntrplvl.toFixed(1)}</span>
                     <Button
                         size="small"
                         type="primary"
                         onClick={() => setSelectedPlayer(p)}
-                        block={screens.xs}
                     >
                         Adjust
                     </Button>
@@ -225,12 +213,7 @@ const PlayersTable = ({ players, loading, fetchPlayers }) => {
             title: 'Role',
             key: 'role',
             render: (p) => (
-                <Flex
-                    vertical={screens.xs}
-                    align="center"
-                    gap="small"
-                    style={{ width: "100%" }}
-                >
+                <Flex align="center" gap="small" style={{ width: "100%" }}>
                     <Text type="secondary" style={{ whiteSpace: "nowrap" }}>
                         {p?.role}
                     </Text>
@@ -239,7 +222,6 @@ const PlayersTable = ({ players, loading, fetchPlayers }) => {
                         size="small"
                         type="primary"
                         onClick={() => toggleAdminRole(p?._id)}
-                        block={screens.xs}
                     >
                         Toggle role
                     </Button>
@@ -248,9 +230,124 @@ const PlayersTable = ({ players, loading, fetchPlayers }) => {
         }
     ];
 
+    // ------------------------------------------------------------------
+    // MOBILE COLUMNS: una sola columna "card" que agrupa todo
+    // ------------------------------------------------------------------
+    const mobileColumns = [
+        {
+            title: "Player",
+            key: "player-mobile",
+            render: (p) => (
+                <Flex vertical gap={8} style={{ width: "100%" }}>
+                    {/* Header: foto + nombre + botón view */}
+                    <Flex align="center" justify="space-between" gap={8}>
+                        <Flex
+                            align="center"
+                            gap={8}
+                            style={{ minWidth: 0, cursor: "pointer" }}
+                            onClick={(e) => {
+                                e.stopPropagation();
+                                navigate(`/admin/player/${p._id}`);
+                            }}
+                        >
+                            <ProfilePicture
+                                profilePicture={p?.profilePicture?.url}
+                                user={p}
+                                size={32}
+                                editable={false}
+                            />
+                            <span
+                                style={{
+                                    fontWeight: 600,
+                                    whiteSpace: "normal",
+                                    wordBreak: "break-word"
+                                }}
+                            >
+                                {p?.name} {p?.lastname}
+                            </span>
+                        </Flex>
+
+                        <Button
+                            type="primary"
+                            size="small"
+                            onClick={(e) => {
+                                e.stopPropagation();
+                                navigate(`/admin/player/${p._id}`);
+                            }}
+                        >
+                            View profile
+                        </Button>
+                    </Flex>
+
+                    {/* Email + phone */}
+                    <Flex vertical gap={0}>
+                        <Text type="secondary" style={{ fontSize: 12 }}>
+                            {p?.email}
+                        </Text>
+                        <Text type="secondary" style={{ fontSize: 12 }}>
+                            {p?.phone}
+                        </Text>
+                    </Flex>
+
+                    {/* País + NTRP (con Adjust) */}
+                    <Flex justify="space-between" align="center" wrap="wrap" gap={8}>
+                        <Flex align="center" gap={6}>
+                            <Image
+                                preview={false}
+                                width={18}
+                                alt={`${p?.country} flag`}
+                                src={p?.countryFlag}
+                            />
+                            <span>{p?.country}</span>
+                        </Flex>
+
+                        <Flex align="center" gap={6}>
+                            <span>NTRP {p?.ntrplvl.toFixed(1)}</span>
+                            <Button
+                                size="small"
+                                type="primary"
+                                onClick={() => setSelectedPlayer(p)}
+                            >
+                                Adjust
+                            </Button>
+                        </Flex>
+                    </Flex>
+
+                    {/* Active + Role */}
+                    <Flex justify="space-between" align="center" wrap="wrap" gap={8}>
+                        <Popconfirm
+                            title={p?.isActive ? "Deactivate player?" : 'Activate player?'}
+                            description={p?.isActive ? "This player will no longer be active" : "This player will be activated"}
+                            okText="Yes"
+                            cancelText="No"
+                            onConfirm={() => toggleActivation(p?._id)}
+                        >
+                            <Checkbox checked={p?.isActive}>
+                                Active
+                            </Checkbox>
+                        </Popconfirm>
+
+                        <Flex align="center" gap={6}>
+                            <Text type="secondary" style={{ whiteSpace: "nowrap" }}>
+                                {p?.role}
+                            </Text>
+                            <Button
+                                size="small"
+                                onClick={() => toggleAdminRole(p?._id)}
+                            >
+                                Toggle role
+                            </Button>
+                        </Flex>
+                    </Flex>
+                </Flex>
+            )
+        }
+    ];
+
+    const columns = screens.xs ? mobileColumns : desktopColumns;
+
     return (
         <>
-
             <Flex gap={4}>
                 <ExportToExcel
                     data={playersWithCountry}
@@ -264,6 +361,7 @@ const PlayersTable = ({ players, loading, fetchPlayers }) => {
                 loading={loading}
                 rowKey="_id"
                 scroll={{ x: "max-content" }}
+                showHeader={!screens.xs}
             />
 
             <NTRPModal

--- a/server/controller/match.js
+++ b/server/controller/match.js
@@ -96,17 +96,19 @@ export const newMatch = async (req, res) => {
 
         /* PUSH NOTIFICATION */   
         const usersNotice = await User.find({
-          isActive:true,
+          isActive: true,
+          _id: { $ne: req.user._id },
           fcmToken: {
             $exists: true,
-            _id: { $ne: userId },
             $ne: null
           }
         }).select("fcmToken");
 
-        const tokens = usersNotice.map(user => user.fcmToken).filter(Boolean);
+        const tokens = usersNotice
+          .map(user => user.fcmToken)
+          .filter(Boolean);
 
-        await sendNewMatchNotification(tokens, location.name)
+        await sendNewMatchNotification(tokens, location.name);
 
         return res.status(201).json(match);
 


### PR DESCRIPTION
Introduce mobile-first responsive table layouts for Matches and Players: use Grid.useBreakpoint, add dedicated mobileColumns (single-card views) and keep desktopColumns for larger screens; compute sortedMatches (most recent first) and pass it to table and Excel export; toggle table header, scroll and layout based on breakpoint; minor UI / spacing cleanups. In server match controller, exclude the match creator from FCM recipients (filter _id !== req.user._id), tidy token mapping/filtering, and finalize call to sendNewMatchNotification. Small formatting and key prop additions.