### PR TITLE
Add NTRP-weighted skill votes and safety limits

### DIFF
--- a/server/controller/skillVote.js
+++ b/server/controller/skillVote.js
@@ -2,6 +2,32 @@ import Match from "../models/Match.js";
 import SkillVote from "../models/Vote.js";
 import User from "../models/user.js";
 
+// Configuración del sistema de peso por NTRP
+const NTRP_MIN = 1;
+const NTRP_MAX = 5;
+const WEIGHT_AT_NTRP_MIN = 0.4;
+const WEIGHT_AT_NTRP_MAX = 1.6;
+const NTRP_NEUTRAL = 3; // nivel que produce peso = 1.0
+
+// impacto base y tope de seguridad por partido
+const VOTE_IMPACT = 0.1;
+const MAX_DELTA_PER_MATCH = 0.15; // ningún voto, sin importar el peso, mueve más de esto en un solo partido
+
+// peso lineal centrado en NTRP_NEUTRAL, clamped a [WEIGHT_AT_NTRP_MIN, WEIGHT_AT_NTRP_MAX]
+const calculateVoteWeight = (voterNTRP) => {
+    const ntrp = voterNTRP || NTRP_NEUTRAL;
+    const slope =
+        ntrp >= NTRP_NEUTRAL
+            ? (WEIGHT_AT_NTRP_MAX - 1) / (NTRP_MAX - NTRP_NEUTRAL)
+            : (1 - WEIGHT_AT_NTRP_MIN) / (NTRP_NEUTRAL - NTRP_MIN);
+
+    const rawWeight = 1 + (ntrp - NTRP_NEUTRAL) * slope;
+
+    return Number(
+        Math.min(WEIGHT_AT_NTRP_MAX, Math.max(WEIGHT_AT_NTRP_MIN, rawWeight)).toFixed(3)
+    );
+};
+
 export const voteSkillLevel = async (req, res) => {
     try {
         const { id: matchId } = req.params;
@@ -30,6 +56,15 @@ export const voteSkillLevel = async (req, res) => {
             return res.status(404).json({
                 ok: false,
                 message: "Voted user not found"
+            });
+        }
+
+        // usuario que vota (necesitamos su NTRP para el peso)
+        const voterUser = await User.findById(voterId);
+        if (!voterUser) {
+            return res.status(404).json({
+                ok: false,
+                message: "Voter user not found"
             });
         }
 
@@ -78,12 +113,18 @@ export const voteSkillLevel = async (req, res) => {
             });
         }
 
+        // calcular peso del voto según NTRP del votante (snapshot en el momento de votar)
+        const voterNTRP = voterUser.ntrplvl || NTRP_NEUTRAL;
+        const weight = calculateVoteWeight(voterNTRP);
+
         // guardar voto
         await SkillVote.create({
             match: matchId,
             votedBy: voterId,
             votedUser: votedUserId,
-            value
+            value,
+            voterNTRP,
+            weight
         });
 
         const votes = await SkillVote.find({
@@ -91,12 +132,18 @@ export const voteSkillLevel = async (req, res) => {
             votedUser: votedUserId
         });
 
-        const totalVotes = votes.reduce((sum, v) => sum + v.value, 0);
-        const avgVote = totalVotes / votes.length;
+        // promedio ponderado por el peso de cada votante
+        // (dividido por el número de votos, NO por la suma de pesos,
+        // para que el peso realmente afecte la magnitud del delta
+        // y no solo la proporción dentro de un promedio acotado a [-1,1])
+        const weightedSum = votes.reduce((sum, v) => sum + v.value * (v.weight || 1), 0);
+        const avgVote = votes.length > 0 ? weightedSum / votes.length : 0;
 
-        // impacto controlado
-        const VOTE_IMPACT = 0.1;
-        const delta = Number((avgVote * VOTE_IMPACT).toFixed(2));
+        // impacto controlado, con tope de seguridad independiente del peso
+        const rawDelta = avgVote * VOTE_IMPACT;
+        const delta = Number(
+            Math.min(MAX_DELTA_PER_MATCH, Math.max(-MAX_DELTA_PER_MATCH, rawDelta)).toFixed(2)
+        );
 
         const oldNTRP = votedUser.ntrplvl || 4;
         const newNTRP = Number((oldNTRP + delta).toFixed(2));
@@ -135,7 +182,6 @@ export const voteSkillLevel = async (req, res) => {
         });
     }
 };
-
 
 export const userVotesPerMatch = async(req, res) =>{
     try {

--- a/server/models/Vote.js
+++ b/server/models/Vote.js
@@ -20,6 +20,12 @@ const skillVoteSchema = new mongoose.Schema({
         type: Number,
         enum: [-1, 0, 1],
         required: true
+    },
+    voterNTRP: {
+        type: Number
+    },
+    weight: {
+        type: Number
     }
 }, {timestamps: true});
 

--- a/server/models/user.js
+++ b/server/models/user.js
@@ -84,7 +84,7 @@
             type: Number,
             //required: true,
             min: 1,
-            max: 7
+            max: 5
         },
         adjustmentHistory:{
             type: [adjustmentHistorySchema],


### PR DESCRIPTION
Introduce NTRP-based vote weighting and per-match delta limits. Added weight calculation (calculateVoteWeight) and constants (NTRP ranges, VOTE_IMPACT, MAX_DELTA_PER_MATCH) in skillVote controller, fetch voter snapshot NTRP, store voterNTRP and weight on Vote, and compute a weighted average (normalized by vote count) with a clamped delta when updating user NTRP. Updated Vote schema to include voterNTRP and weight. Also adjusted user.ntrplvl max from 7 to 5 to match NTRP bounds.