### PR TITLE
Profile & Match UI tweaks; fix skill-vote baseline

### DIFF
--- a/client/src/components/profile/ProfileHeader.jsx
+++ b/client/src/components/profile/ProfileHeader.jsx
@@ -1,55 +1,125 @@
-import { Row, Col, Typography, Tag, Space, Statistic } from "antd"
-import ProfilePicture from "../uploads/ProfilePicture"
+import {
+    Row,
+    Col,
+    Typography,
+    Tag,
+    Space,
+    Statistic,
+} from "antd";
+import ProfilePicture from "../uploads/ProfilePicture";
 import dayjs from "dayjs";
 
-
+const { Text, Title } = Typography;
+const { Timer } = Statistic;
 
 const ProfileHeader = ({ user, editable }) => {
 
-    const { Text, Title } = Typography;
-
-    const isSuspended = user?.suspendedUntil && new Date(user.suspendedUntil) > new Date()
-
-    const { Timer } = Statistic;
+    const isSuspended =
+        user?.suspendedUntil &&
+        new Date(user.suspendedUntil) > new Date();
 
     return (
-        <Row gutter={[16, 16]} align="middle">
-            <Col xs={24} sm={8} md={6} style={{ textAlign: "center" }}>
-                <ProfilePicture user={user} profilePicture={user?.profilePicture?.url} editable={editable} />
+        <Row
+            align="middle"
+            gutter={[20, 16]}
+            style={{
+                width: "100%",
+            }}
+        >
+            {/* PROFILE PICTURE */}
+            <Col
+                flex="0 0 110px"
+                style={{
+                    display: "flex",
+                    justifyContent: "center",
+                }}
+            >
+                <ProfilePicture
+                    user={user}
+                    profilePicture={user?.profilePicture?.url}
+                    editable={editable}
+                />
             </Col>
 
-            <Col xs={24} sm={16} md={18}>
-                <Title level={3} style={{ marginBottom: 8 }}>
+            {/* PROFILE INFO */}
+            <Col
+                flex="1"
+                style={{
+                    minWidth: 0,
+                }}
+            >
+                <Title
+                    level={3}
+                    style={{
+                        margin: 0,
+                        marginBottom: 8,
+                        wordBreak: "break-word",
+                    }}
+                >
                     {user?.name} {user?.lastname}
                 </Title>
 
-                <Space wrap size="middle">
-                    <Tag color={user?.isActive ? "green" : "red"}>
-                        {user?.isActive ? "Active user" : "Inactive user"}
+                <Space
+                    wrap
+                    size={[8, 8]}
+                    style={{
+                        maxWidth: "100%",
+                    }}
+                >
+                    <Tag
+                        color={
+                            user?.isActive
+                                ? "green"
+                                : "red"
+                        }
+                    >
+                        {user?.isActive
+                            ? "Active user"
+                            : "Inactive user"}
                     </Tag>
 
                     <Tag color="gold">
-                        NTRP Level: {user?.ntrplvl.toFixed(1)}
+                        NTRP Level:{" "}
+                        {user?.ntrplvl?.toFixed(1)}
                     </Tag>
 
                     {isSuspended && (
-                        <Tag color='volcano' style={{ fontSize: 14, padding: "4px 12px" }}>
+                        <Tag
+                            color="volcano"
+                            style={{
+                                fontSize: 14,
+                                padding: "4px 12px",
+                            }}
+                        >
                             Temporarily Suspended
                         </Tag>
                     )}
                 </Space>
 
-                <Text type="secondary" style={{ display: "block", marginTop: 8 }}>
-                    Member since {dayjs(user?.createdAt).format("DD-MM-YYYY")}
+                <Text
+                    type="secondary"
+                    style={{
+                        display: "block",
+                        marginTop: 8,
+                    }}
+                >
+                    Member since{" "}
+                    {dayjs(user?.createdAt).format(
+                        "DD-MM-YYYY"
+                    )}
                 </Text>
 
                 {isSuspended && (
                     <div style={{ marginTop: 16 }}>
                         <Timer
-                            title='Suspension ends in'
+                            title="Suspension ends in"
                             type="countdown"
-                            value={new Date(user.suspendedUntil).getTime()}
-                            format="D [days] H [hours] m [minutes] s [seconds]"
+                            value={
+                                new Date(
+                                    user.suspendedUntil
+                                ).getTime()
+                            }
+                            format="D [days] H [hours] m [minutes] s"
                             onFinish={() => {
                                 window.location.reload();
                             }}
@@ -58,7 +128,7 @@ const ProfileHeader = ({ user, editable }) => {
                 )}
             </Col>
         </Row>
-    )
-}
+    );
+};
 
-export default ProfileHeader
+export default ProfileHeader;

--- a/client/src/pages/matches/MatchVote.jsx
+++ b/client/src/pages/matches/MatchVote.jsx
@@ -6,8 +6,12 @@ import {
   Typography,
   Button,
   Spin,
+  Alert,
 } from "antd";
-import { ReloadOutlined } from "@ant-design/icons";
+import {
+  ReloadOutlined,
+  InfoCircleOutlined,
+} from "@ant-design/icons";
 
 import { useAuth } from "../../context";
 import { useMatches } from "../../context/MatchContext";
@@ -17,7 +21,7 @@ import VoteCard from "../../components/matches/VoteCard";
 import EmptyVote from "../../components/matches/EmptyVote";
 import TennisLoader from "../../components/Animations/TennisLoader";
 
-const { Title } = Typography;
+const { Title, Text } = Typography;
 
 const MatchVote = () => {
   const {
@@ -72,7 +76,8 @@ const MatchVote = () => {
           onClick={() => fetchMatches()}
           size="large"
           style={{
-            background: "linear-gradient(135deg, #7CB342 0%, #43A047 100%)",
+            background:
+              "linear-gradient(135deg, #7CB342 0%, #43A047 100%)",
             border: "none",
             borderRadius: 999,
             fontWeight: 700,
@@ -95,6 +100,51 @@ const MatchVote = () => {
         </Button>
       </Space>
 
+      {/* VOTING INFORMATION */}
+      <Alert
+        type="info"
+        showIcon
+        icon={<InfoCircleOutlined />}
+        title="How skill voting works"
+        description={
+          <Space
+            orientation="vertical"
+            size={4}
+            style={{ width: "100%" }}
+          >
+            <Text>
+              Rate the players you played with based on their performance
+              in this match.
+            </Text>
+
+            <Text>
+              <strong>−1</strong> → Below your level&nbsp;&nbsp;·&nbsp;&nbsp;
+              <strong>0</strong> → Similar level&nbsp;&nbsp;·&nbsp;&nbsp;
+              <strong>+1</strong> → Above your level
+            </Text>
+
+            <Text>
+              Your vote is <strong>anonymous</strong> and contributes to the
+              player's skill rating. Votes from higher-rated players have
+              slightly more influence, helping keep the rating accurate.
+            </Text>
+
+            <Text>
+              A player's rating can change by <strong>no more than 0.15
+                points</strong> from a single match.
+            </Text>
+
+            <Text type="secondary">
+              Please vote based on what you actually saw on court and be fair.
+            </Text>
+          </Space>
+        }
+        style={{
+          marginBottom: 20,
+          borderRadius: 10,
+        }}
+      />
+
       <Spin
         spinning={loadMatches}
         indicator={<TennisLoader />}
@@ -104,7 +154,13 @@ const MatchVote = () => {
         ) : (
           <Row gutter={[16, 16]}>
             {voteMatches.map((m) => (
-              <Col key={m._id} lg={12} md={16} sm={24} xs={24}>
+              <Col
+                key={m._id}
+                lg={12}
+                md={16}
+                sm={24}
+                xs={24}
+              >
                 <VoteCard
                   match={m}
                   loadMatches={loadMatches}

--- a/server/controller/skillVote.js
+++ b/server/controller/skillVote.js
@@ -145,8 +145,19 @@ export const voteSkillLevel = async (req, res) => {
             Math.min(MAX_DELTA_PER_MATCH, Math.max(-MAX_DELTA_PER_MATCH, rawDelta)).toFixed(2)
         );
 
-        const oldNTRP = votedUser.ntrplvl || 4;
-        const newNTRP = Number((oldNTRP + delta).toFixed(2));
+        // buscar si ya existe un ajuste previo para este partido
+        // (para usar el NTRP ORIGINAL (previo al partido) como base, y no el
+        // NTRP ya modificado por votos anteriores de este mismo partido —
+        // si no, el delta se acumula voto tras voto y el clamp deja de proteger
+        // el impacto total del partido)
+        const existingAdjustment = votedUser.adjustmentHistory.find(
+            h => h.match?.toString() === matchId
+        );
+        const baselineNTRP = existingAdjustment
+            ? existingAdjustment.previousNTRP
+            : (votedUser.ntrplvl || 4);
+
+        const newNTRP = Number((baselineNTRP + delta).toFixed(2));
 
         votedUser.ntrplvl = newNTRP;
 
@@ -155,13 +166,13 @@ export const voteSkillLevel = async (req, res) => {
             h => h.match?.toString() !== matchId
         );
 
-        // guardar ajuste CONSENSO
+        // guardar ajuste CONSENSO (siempre referenciado al NTRP previo al partido)
         votedUser.adjustmentHistory.push({
             match: matchId,
-            previousNTRP: oldNTRP,
+            previousNTRP: baselineNTRP,
             change: delta,
             currentNTRP: newNTRP,
-            reason: "Match-average",
+            reason: "Match-average-weighted",
             at: new Date()
         });
 

--- a/server/models/user.js
+++ b/server/models/user.js
@@ -1,8 +1,12 @@
-    import mongoose from "mongoose";
+import mongoose from "mongoose";
     import bcrypt  from 'bcryptjs';
 
 
     const adjustmentHistorySchema = new mongoose.Schema({
+        match: {
+            type: mongoose.Schema.Types.ObjectId,
+            ref: "Match"
+        },
         change:{
             type: Number,
             required: true


### PR DESCRIPTION
Refactor ProfileHeader layout and styling (responsive picture, spacing, countdown format). Add an informational Alert to MatchVote explaining skill-voting rules and minor layout cleanups. Fix skill voting logic so votes for the same match use the original pre-match NTRP as baseline (prevents cumulative deltas); store adjustments referencing that baseline and mark reason as "Match-average-weighted". Add a match ObjectId ref to adjustmentHistory in the User model. Minor formatting/cleanup changes across files.