### PR TITLE
Use data payload for push notifications

### DIFF
--- a/client/public/firebase-messaging-sw.js
+++ b/client/public/firebase-messaging-sw.js
@@ -18,7 +18,7 @@ const messaging = firebase.messaging();
 messaging.onBackgroundMessage(function (payload) {
   const notificationTitle = payload.notification?.title || "Weekly Tennis";
   const notificationOptions = {
-    body: payload.notification?.body || "",
+    body: payload.data?.body || "",
     icon: "/tenis-logo.png", // opcional, pon el que tengas
     data: {
       url: payload.data?.url || "https://weekly-tennis-match.vercel.app/games"

--- a/server/services/notificationService.js
+++ b/server/services/notificationService.js
@@ -21,11 +21,11 @@ export const sendNotification = async(tokens, title, body, data) =>{
 
     try {
         const message = {
-            notification: {
+            data:{
                 title,
-                body
+                body,
+                ...data
             },
-            data,
             tokens
         }
 


### PR DESCRIPTION
Switch push message format to use the data payload instead of the notification field. Updated firebase-messaging-sw.js to read body and url from payload.data (so background notifications show the correct body and link). Updated server/services/notificationService.js to send message.data with title, body and merged extra data (and tokens) instead of a notification object, ensuring consistent handling of background messages and custom URL data.