### PR TITLE
Adjust refresh cookie SameSite policy

### DIFF
--- a/server/utils/generateToken.js
+++ b/server/utils/generateToken.js
@@ -20,8 +20,8 @@ export const setRefreshCookie = (res, raw, expiresAt) => {
     res.cookie("refreshToken", raw, {
         httpOnly: true,
         secure: process.env.NODE_ENV === "production",
-        sameSite: "strict",
-        path: "/api/user", // <- coincide con tu prefix real
+        sameSite: process.env.NODE_ENV === "production" ? "none" : "lax", 
+        path: "/api/user",
         expires: expiresAt
     });
 };


### PR DESCRIPTION
Update the refresh token cookie configuration to use `SameSite=none` in production and `lax` otherwise. This keeps the cookie compatible with cross-site browser behavior while preserving the API-scoped path at `/api/user`.