### PR TITLE
Restrict wallet payments behind user flag

### DIFF
--- a/client/src/components/matches/JoinMatch.jsx
+++ b/client/src/components/matches/JoinMatch.jsx
@@ -22,6 +22,7 @@ const JoinMatch = ({ openMatches = [], loading, fetchMatches }) => {
   const {user, loadUser} = useAuth();
 
   const balance = user?.walletBalance;
+  const walletPaymentAllowed = user?.walletPaymentAllowed
 
   // 🔵 AÑADIDO
   const [selectedMatch, setSelectedMatch] = useState(null);
@@ -181,6 +182,7 @@ const JoinMatch = ({ openMatches = [], loading, fetchMatches }) => {
             selectedMatch.maxPlayers
           ).toFixed(2)}
           balance={balance}
+          walletPaymentAllowed={walletPaymentAllowed}
         />
       )}
     </>

--- a/client/src/components/matches/PaymentModal.jsx
+++ b/client/src/components/matches/PaymentModal.jsx
@@ -9,10 +9,13 @@ const PaymentModal = ({
     onConfirm,
     paymentMethods = [],
     price,
-    balance
+    balance,
+    walletPaymentAllowed
 }) => {
 
     const [selectedPayment, setSelectedPayment] = useState(null);
+
+    console.log(walletPaymentAllowed)
 
     useEffect(() => {
         if (!open) {
@@ -57,7 +60,9 @@ const PaymentModal = ({
                     style={{ width: "100%" }}
                     size="middle"
                 >
-                    {paymentMethods.map((pm) => {
+                    {paymentMethods
+                        .filter((pm) => pm.type !== 'wallet' || walletPaymentAllowed) 
+                        .map((pm) => {
 
                         const isWallet = pm.type === "wallet";
                         const isDisabled =

--- a/server/controller/match.js
+++ b/server/controller/match.js
@@ -457,6 +457,11 @@ export const joinMatch = async (req, res) => {
 
     if (paymentMethod === "wallet") {
 
+      //wallet for allowed only
+      if(!user.walletPaymentAllowed){
+        throw new Error("Wallet payment not available for this user")
+      }
+
       //  precio estimado por jugador
       const estimatedPrice = Math.round((match.price / match.maxPlayers) * 100) / 100;;
 

--- a/server/models/user.js
+++ b/server/models/user.js
@@ -153,6 +153,11 @@ const userSchema = new mongoose.Schema({
         type: Number,
         default: 0
     },
+    /* allows the user to receive wallet payments */
+    walletPaymentAllowed: {
+        type: Boolean,
+        default: false
+    },
     lastMatchPlayed: {
         type: Date,
         default: null

--- a/server/services/notificationService.js
+++ b/server/services/notificationService.js
@@ -58,7 +58,7 @@ export const sendJoinMatchNotification = async (tokens, playerName, locationName
     return sendNotification(
         tokens,
         "🎾 New Player Joined",
-        `${playerName} just joined your match at ${locationName}.`,
+        `${playerName} just joined match at ${locationName}.`,
         {
             type: "PLAYER_JOINED"
         }

--- a/server/utils/userProjections.js
+++ b/server/utils/userProjections.js
@@ -1,3 +1,13 @@
 
-export const PUBLIC_USER_FIELDS =
-    "name lastname email role isActive ntrplvl adjustmentHistory profilePicture country walletBalance phone suspendedUntil termsAndConditions notesHistory createdAt";
+export const PUBLIC_USER_FIELDS = `
+name lastname email role isActive 
+ntrplvl adjustmentHistory profilePicture country 
+walletBalance phone suspendedUntil 
+termsAndConditions notesHistory createdAt 
+walletPaymentAllowed
+`
+
+
+
+
+    


### PR DESCRIPTION
Introduce walletPaymentAllowed on User (boolean, default false) and expose it in public user projections. Frontend: pass walletPaymentAllowed from JoinMatch to PaymentModal and filter out wallet payment option when the flag is false. Backend: enforce the flag in joinMatch to prevent wallet payments for disallowed users. Also include a minor notification copy tweak for join messages. These changes ensure wallet payments are only available to authorized users and add a server-side safeguard.