### PR TITLE
Use creator's walletPaymentAllowed for payments

### DIFF
--- a/client/src/components/matches/JoinMatch.jsx
+++ b/client/src/components/matches/JoinMatch.jsx
@@ -22,11 +22,12 @@ const JoinMatch = ({ openMatches = [], loading, fetchMatches }) => {
   const {user, loadUser} = useAuth();
 
   const balance = user?.walletBalance;
-  const walletPaymentAllowed = user?.walletPaymentAllowed
 
   // 🔵 AÑADIDO
   const [selectedMatch, setSelectedMatch] = useState(null);
   const [paymentModal, setPaymentModal] = useState(false);
+
+  const walletPaymentAllowed = selectedMatch?.createdBy?.walletPaymentAllowed === true
 
 
   const handleJoin = async (id, backup = false, paymentMethod = null) => {

--- a/client/src/components/matches/PaymentModal.jsx
+++ b/client/src/components/matches/PaymentModal.jsx
@@ -15,8 +15,6 @@ const PaymentModal = ({
 
     const [selectedPayment, setSelectedPayment] = useState(null);
 
-    console.log(walletPaymentAllowed)
-
     useEffect(() => {
         if (!open) {
             setSelectedPayment(null);

--- a/client/src/pages/dashboard/UserDashboard.jsx
+++ b/client/src/pages/dashboard/UserDashboard.jsx
@@ -16,8 +16,6 @@ const UserDashboard = () => {
     (match) => match.status !== "Played"
   );
 
-
-
   return (
     <>
       <Space

--- a/server/controller/match.js
+++ b/server/controller/match.js
@@ -127,7 +127,7 @@ export const getAllMatches = async (req, res) => {
             .populate('location', 'name address courts')
             .populate('players.user', 'name lastname ntrplvl profilePicture')
             .populate('backUps.user', 'name lastname ntrplvl profilePicture')
-            .populate('createdBy', 'name lastname')
+            .populate('createdBy', 'name lastname walletPaymentAllowed')
             .populate('generatedMatches.teamA.player1', 'name lastname ntrplvl profilePicture')
             .populate('generatedMatches.teamA.player2', 'name lastname ntrplvl profilePicture')
             .populate('generatedMatches.teamB.player1', 'name lastname ntrplvl profilePicture')
@@ -172,7 +172,7 @@ export const getMatch = async (req, res) => {
             .populate('location', 'name address courts')
             .populate('players.user', 'name lastname ntrplvl profilePicture')
             .populate('backUps.user', 'name lastname ntrplvl profilePicture')
-            .populate('createdBy', 'name lastname')
+            .populate('createdBy', 'name lastname walletPaymentAllowed')
             .populate('generatedMatches.teamA.player1', 'name lastname ntrplvl profilePicture')
             .populate('generatedMatches.teamA.player2', 'name lastname ntrplvl profilePicture')
             .populate('generatedMatches.teamB.player1', 'name lastname ntrplvl profilePicture')
@@ -222,7 +222,7 @@ export const getOpenMatch = async (req, res) => {
             .populate('location', 'name address courts')
             .populate('players.user', 'name lastname ntrplvl profilePicture')
             .populate('backUps.user', 'name lastname ntrplvl profilePicture')
-            .populate('createdBy', 'name lastname')
+            .populate('createdBy', 'name lastname walletPaymentAllowed')
             .populate('generatedMatches.teamA.player1', 'name lastname ntrplvl profilePicture')
             .populate('generatedMatches.teamA.player2', 'name lastname ntrplvl profilePicture')
             .populate('generatedMatches.teamB.player1', 'name lastname ntrplvl profilePicture')
@@ -436,7 +436,9 @@ export const joinMatch = async (req, res) => {
       throw new Error("Payment method required");
     }
 
-    const match = await Match.findById(id).session(session).populate('location', 'name')
+    const match = await Match.findById(id).session(session)
+                  .populate('location', 'name')
+                  .populate('createdBy', 'walletPaymentAllowed');
 
 
     if (!match) {
@@ -458,7 +460,7 @@ export const joinMatch = async (req, res) => {
     if (paymentMethod === "wallet") {
 
       //wallet for allowed only
-      if(!user.walletPaymentAllowed){
+      if(!match.createdBy?.walletPaymentAllowed){
         throw new Error("Wallet payment not available for this user")
       }
 


### PR DESCRIPTION
Populate and check the match creator's walletPaymentAllowed flag instead of the current user. Server: include createdBy.walletPaymentAllowed in getAllMatches, getMatch, getOpenMatch and populate createdBy in joinMatch; validate wallet payments against match.createdBy.walletPaymentAllowed. Client: switch JoinMatch to read walletPaymentAllowed from the selected match's creator (added selectedMatch/paymentModal state) and remove a stray console.log in PaymentModal. Also small whitespace cleanup in UserDashboard.