### PR TITLE
Add geo-blocking middleware (geoip-lite)

### DIFF
--- a/server/middlewares/geoBlock.js
+++ b/server/middlewares/geoBlock.js
@@ -1,0 +1,28 @@
+// middlewares/geoBlock.js
+import geoip from 'geoip-lite';
+import { BLOCKED_COUNTRIES, EU_CONTINENT_CODE } from '../utils/blockedCountries.js';
+
+export const geoBlock = (req, res, next) => {
+  // Render pone la IP real del cliente en x-forwarded-for
+  const ip = req.headers['x-forwarded-for']?.split(',')[0].trim() || req.socket.remoteAddress;
+
+  const geo = geoip.lookup(ip);
+  const country = geo?.country;   // ej "ES"
+  const continent = geo?.continent; // ej "EU"
+
+  if (country && country !== 'ES') {
+    console.log(`[fuera de España] country=${country} ip=${ip} path=${req.originalUrl}`);
+  }
+
+  if (!geo) return next(); // sin datos de geo (ej. IP local en dev), dejamos pasar
+
+  if (BLOCKED_COUNTRIES.includes(country)) {
+    return res.status(403).json({ error: 'GEO_BLOCKED', message: 'Este servicio no está disponible en tu región.' });
+  }
+
+  if (continent !== EU_CONTINENT_CODE) {
+    return res.status(403).json({ error: 'GEO_BLOCKED', message: 'Este servicio no está disponible en tu región.' });
+  }
+
+  next();
+};

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -22,6 +22,7 @@
         "express-validator": "^7.3.1",
         "file-type": "^21.3.0",
         "firebase-admin": "^13.6.0",
+        "geoip-lite": "^2.0.3",
         "helmet": "^8.1.0",
         "jsonwebtoken": "^9.0.3",
         "mongodb": "^7.2.0",
@@ -1156,7 +1157,6 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "optional": true,
       "dependencies": {
         "color-convert": "^2.0.1"
       },
@@ -1400,6 +1400,21 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
     "node_modules/cliui": {
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
@@ -1429,7 +1444,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "optional": true,
       "dependencies": {
         "color-name": "~1.1.4"
       },
@@ -1440,8 +1454,7 @@
     "node_modules/color-name": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "optional": true
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
     },
     "node_modules/combined-stream": {
       "version": "1.0.8",
@@ -2168,6 +2181,40 @@
         "url": "https://opencollective.com/node-fetch"
       }
     },
+    "node_modules/geoip-lite": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/geoip-lite/-/geoip-lite-2.0.3.tgz",
+      "integrity": "sha512-I0v/6sITK5FhEXHmatGSPBMply2nHN/2D743LIx4KkksttZt/E505lDaV6qUwt5RM08MbZW+/4E0KxusLVN39w==",
+      "dependencies": {
+        "chalk": "4.1 - 4.1.2",
+        "iconv-lite": "0.4.13 - 0.6.3",
+        "ip-address": "^10.2.0",
+        "lazy": "1.0.11",
+        "yauzl": "^3.3.1"
+      },
+      "engines": {
+        "node": ">=24.0.0"
+      }
+    },
+    "node_modules/geoip-lite/node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/geoip-lite/node_modules/ip-address": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.5.0.tgz",
+      "integrity": "sha512-R5SnVLJmgYYvf2F2ZgwSBnelz5G4q5AxIC277GDfUaNbrZKNANcBC7RHqYYePlszf4kBolVkJauG0ZjHHFh55g==",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
     "node_modules/get-caller-file": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
@@ -2337,6 +2384,14 @@
       },
       "engines": {
         "node": ">=14.0.0"
+      }
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/has-symbols": {
@@ -2642,6 +2697,14 @@
       "integrity": "sha512-RKhaOBSPN8L7y4yAgNhDT2602G5FD6QbOIISbjN9D6mjHPeqeg7K+EB5IGSU5o81/X2Gzm3ICnAvQW3x3OP8HA==",
       "engines": {
         "node": ">=18.0.0"
+      }
+    },
+    "node_modules/lazy": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/lazy/-/lazy-1.0.11.tgz",
+      "integrity": "sha512-Y+CjUfLmIpoUCCRl0ub4smrYtGGr5AOa2AKOaWelGHOGz33X/Y/KizefGqbkwfz44+cnq/+9habclf8vOmu2LA==",
+      "engines": {
+        "node": ">=0.2.0"
       }
     },
     "node_modules/limiter": {
@@ -3286,6 +3349,11 @@
         "type": "opencollective",
         "url": "https://opencollective.com/express"
       }
+    },
+    "node_modules/pend": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
+      "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg=="
     },
     "node_modules/pg": {
       "version": "8.20.0",
@@ -3995,6 +4063,17 @@
       "integrity": "sha512-PdHt7hHUJKxvTCgbKX9C1V/ftOcjJQgz8BZwNfV5c4B6dcGqlpelTbJ999jBGZ2jYiPAwcX5dP6oBwVlBlUbxw==",
       "optional": true
     },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/svix": {
       "version": "1.76.1",
       "resolved": "https://registry.npmjs.org/svix/-/svix-1.76.1.tgz",
@@ -4352,6 +4431,17 @@
       "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
       "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
       "optional": true,
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yauzl": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-3.4.0.tgz",
+      "integrity": "sha512-jIH9yLR9wqr0wOS0TpBvo/g/2UgZH5qePVbjgRliiF0BYvOZyaBknKsF+x9Iht0O6sqgnB93rCICdOZFecJuDw==",
+      "dependencies": {
+        "pend": "~1.2.0"
+      },
       "engines": {
         "node": ">=12"
       }

--- a/server/package.json
+++ b/server/package.json
@@ -25,6 +25,7 @@
     "express-validator": "^7.3.1",
     "file-type": "^21.3.0",
     "firebase-admin": "^13.6.0",
+    "geoip-lite": "^2.0.3",
     "helmet": "^8.1.0",
     "jsonwebtoken": "^9.0.3",
     "mongodb": "^7.2.0",

--- a/server/server.js
+++ b/server/server.js
@@ -20,6 +20,7 @@ import './jobs/matchStatus.js'
 import { globalLimiter } from './config/expressLimit.js';
 import helmet from 'helmet'
 import cookieParser from 'cookie-parser';
+import { geoBlock } from './middlewares/geoBlock.js';
 
 
 
@@ -49,6 +50,7 @@ app.use(cors({
   },
   credentials: true
 }));
+app.use(geoBlock)
 app.use(globalLimiter)
 app.use(express.json());
 app.use(morgan("dev"));

--- a/server/utils/blockedCountries.js
+++ b/server/utils/blockedCountries.js
@@ -1,0 +1,3 @@
+export const BLOCKED_COUNTRIES = ['RU', 'BY', 'UA', 'MK']
+
+export const EU_CONTINENT_CODE = 'EU';


### PR DESCRIPTION
Introduce geoBlock middleware using geoip-lite to inspect client IP (x-forwarded-for / socket) and block requests from a configured list (RU, BY, UA, MK) or any non-EU continent. Adds server/utils/blockedCountries.js and registers the middleware in server.js. Adds geoip-lite to dependencies and updates package-lock.json. Returns 403 with error code GEO_BLOCKED for blocked regions and logs non-ES countries for observability.