### PR TITLE
Use country whitelist for EU geo-blocking

### DIFF
--- a/server/middlewares/geoBlock.js
+++ b/server/middlewares/geoBlock.js
@@ -1,26 +1,23 @@
 // middlewares/geoBlock.js
 import geoip from 'geoip-lite';
-import { BLOCKED_COUNTRIES, EU_CONTINENT_CODE } from '../utils/blockedCountries.js';
+import { EUROPEAN_COUNTRIES, BLOCKED_COUNTRIES } from '../utils/blockedCountries.js';
 
 export const geoBlock = (req, res, next) => {
-  // Render pone la IP real del cliente en x-forwarded-for
-  const ip = req.headers['x-forwarded-for']?.split(',')[0].trim() || req.socket.remoteAddress;
-
+  const ip = (req.headers['x-forwarded-for']?.split(',')[0].trim() || req.socket.remoteAddress || '').replace('::ffff:', '');
   const geo = geoip.lookup(ip);
-  const country = geo?.country;   // ej "ES"
-  const continent = geo?.continent; // ej "EU"
+  const country = geo?.country;
 
   if (country && country !== 'ES') {
     console.log(`[fuera de España] country=${country} ip=${ip} path=${req.originalUrl}`);
   }
 
-  if (!geo) return next(); // sin datos de geo (ej. IP local en dev), dejamos pasar
+  if (!geo) return next();
 
   if (BLOCKED_COUNTRIES.includes(country)) {
     return res.status(403).json({ error: 'GEO_BLOCKED', message: 'This service is not available in your region' });
   }
 
-  if (continent !== EU_CONTINENT_CODE) {
+  if (!EUROPEAN_COUNTRIES.includes(country)) {
     return res.status(403).json({ error: 'GEO_BLOCKED', message: 'This service is not available in your region' });
   }
 

--- a/server/utils/blockedCountries.js
+++ b/server/utils/blockedCountries.js
@@ -1,3 +1,8 @@
 export const BLOCKED_COUNTRIES = ['RU', 'BY', 'UA', 'MK']
 
-export const EU_CONTINENT_CODE = 'EU';
+export const EUROPEAN_COUNTRIES = [
+  'ES','FR','PT','IT','DE','GB','IE','NL','BE','LU','CH','AT',
+  'DK','SE','NO','FI','IS','PL','CZ','SK','HU','SI','HR','RO',
+  'BG','GR','CY','MT','EE','LV','LT','MD',
+  'AL','BA','ME','RS','XK','AD','MC','LI','SM','VA'
+];


### PR DESCRIPTION
Update geoBlock middleware to determine location by country code and a new EUROPEAN_COUNTRIES whitelist instead of relying on continent code. Also normalize client IP (strip ::ffff:), keep blocked-country checks via BLOCKED_COUNTRIES, and early-return when geo lookup is missing. Added EUROPEAN_COUNTRIES array in server/utils/blockedCountries.js and removed the EU_CONTINENT_CODE export. This ensures more accurate EU membership checks and handles proxied IPv4 addresses correctly.