### PR TITLE
Support 'Playing' status and add wallet alert

### DIFF
--- a/client/src/components/matches/MatchPlayers.jsx
+++ b/client/src/components/matches/MatchPlayers.jsx
@@ -77,7 +77,7 @@ const MatchPlayers = () => {
 
   if (pageLoading || !match) return <LoadingSpinner />;
 
-  const isReady = match.status === "Ready";
+  const isReady = match?.status === "Ready" || match?.status === 'Playing';
 
   return (
     <div style={{ padding: 20 }}>
@@ -134,7 +134,7 @@ const MatchPlayers = () => {
       </Row>
 
       {/* READY STATE */}
-      {isReady ? (
+      {isReady  ? (
         <Row gutter={[24, 24]}>
           {match.generatedMatches?.map((m, index) => (
             <Col key={index} xs={24} sm={12} lg={12}>

--- a/client/src/pages/dashboard/UserDashboard.jsx
+++ b/client/src/pages/dashboard/UserDashboard.jsx
@@ -14,7 +14,7 @@ const UserDashboard = () => {
   const { user } = useAuth();
 
   const openMatch = openMatches.filter(
-    (match) => match.status !== "Played"
+    (match) => match.status !== "Played"  
   );
 
   return (

--- a/client/src/pages/wallet/Wallet.jsx
+++ b/client/src/pages/wallet/Wallet.jsx
@@ -1,4 +1,4 @@
-import { Col, Row, Grid, Card } from "antd"
+import { Col, Row, Grid, Card, Alert } from "antd"
 import { useAuth } from "../../context";
 import WalletBalance from "../../components/wallet/WalletBalance";
 import TransactionsTable from "../../components/wallet/TransactionsTable";
@@ -19,6 +19,55 @@ const Wallet = () => {
 
     return (
         <>
+            <Alert
+                title='How wallet works'
+                type="info"
+                showIcon
+                description={
+                    <div>
+                        <b>Note: This feature does not automatically send money via Bizum, PayPal, or any other payment method.</b>
+
+                        <p>
+                            Instead of making a separate payment for every match, you can send a larger
+                            amount to the organizer in advance and keep the funds in your wallet for
+                            future matches.
+                        </p>
+
+                        <ol>
+                            <li>
+                                <strong>Make a payment:</strong> Pay the organizer via Bizum, PayPal,
+                                or any other available payment method.
+                            </li>
+
+                            <li>
+                                <strong>Submit your payment:</strong> Click "Add Funds" and select the
+                                payment method you used to send the money. For example, if you sent a
+                                Bizum to the organizer, select Bizum.
+                            </li>
+
+                            <li>
+                                <strong>Payment confirmation:</strong> You and the organizer will receive
+                                a confirmation that the payment has been submitted.
+                            </li>
+
+                            <li>
+                                <strong>Funds are added:</strong> Once the organizer confirms that the
+                                payment has been received, the amount will be added to your wallet balance.
+                            </li>
+
+                            <li>
+                                <strong>Get notified:</strong> You will receive an email notification
+                                once your wallet has been credited.
+                            </li>
+                        </ol>
+
+                        <p>
+                            <strong>Important:</strong> Wallet funds are intended for future matches only
+                            and cannot be used to pay for matches that have already been played.
+                        </p>
+                    </div>
+                }
+            />
             <Row gutter={[16, 16]}>
                 <Col xs={24} md={24}>
                     <WalletBalance

--- a/server/controller/match.js
+++ b/server/controller/match.js
@@ -225,7 +225,7 @@ export const getOpenMatch = async (req, res) => {
     try {
         const matches = await Match.find({
                 status: {
-                  $in: ['Open', 'Full', 'Ready', 'Played']
+                  $in: ['Open', 'Full', 'Ready', 'Played', 'Playing']
                 }
             })
             .sort({'date': 1})


### PR DESCRIPTION
Treat matches with status 'Playing' as ready in the UI (MatchPlayers) and include 'Playing' in the server's open-match query (getOpenMatch) so these matches are returned. Add an informational Alert to the Wallet page (imported from antd) explaining how the wallet workflow works and that payments are handled externally. Also trim a trailing space in UserDashboard's openMatches filter. These changes improve visibility for active matches and clarify wallet usage for users.