### PR TITLE
Support booker role and refine lastMatchPlayed update

### DIFF
--- a/client/src/components/matches/MatchPlayers.jsx
+++ b/client/src/components/matches/MatchPlayers.jsx
@@ -103,7 +103,7 @@ const MatchPlayers = () => {
 
 
 
-        {(user?.role === 'admin' && match.generatedMatches?.length > 0) && (
+        {((user?.role === 'admin' || user?.role === 'booker') && match.generatedMatches?.length > 0) && (
           <Col xs={24} md={4} style={{ textAlign: "right", marginTop: 12 }}>
             <Button
               icon={<EditOutlined />}
@@ -178,7 +178,7 @@ const MatchPlayers = () => {
                           </div>
 
                         </Flex>
-                        {user?.role === 'admin' && (
+                        {(user?.role === 'admin' || user?.role === 'booker') && (
                           <Flex
                             align="center"
                             gap={8}

--- a/server/jobs/matchStatus.js
+++ b/server/jobs/matchStatus.js
@@ -136,37 +136,44 @@ cron.schedule(
             de los jugadores del partido.
           */
 
-          await User.updateMany(
-            {
-              _id: {
-                $in: match.players.map(
-                  (player) => player.user
-                ),
-              },
+          const lastMatchPlayed = endDate.toDate();
 
-              $or: [
-                {
-                  lastMatchPlayed: {
-                    $exists: false,
-                  },
-                },
-                {
-                  lastMatchPlayed: {
-                    $lt: match.date,
-                  },
-                },
-              ],
-            },
-            {
-              $set: {
-                lastMatchPlayed: match.date,
-              },
-            }
-          );
+          const userIds = match.players
+                            .map((player) => player.user)
+                            .filter(Boolean)
 
-          console.log(
-            `${match._id} → Played`
-          );
+          
+
+         await User.updateMany(
+                  {
+                    _id: {
+                      $in: userIds,
+                    },
+
+                    $or: [
+                      {
+                        lastMatchPlayed: {
+                          $exists: false,
+                        },
+                      },
+                      {
+                        lastMatchPlayed: {
+                          $lt: lastMatchPlayed,
+                        },
+                      },
+                    ],
+                  },
+                  {
+                    $set: {
+                      lastMatchPlayed,
+                    },
+                  }
+                );
+
+        console.log(
+          `${match._id} → Played | ${userIds.length} usuarios actualizados`
+        );
+    
         }
       }
 

--- a/server/routes/admin.js
+++ b/server/routes/admin.js
@@ -1,5 +1,5 @@
 import {Router} from 'express';
-import { protect, verifyAdmin } from '../middlewares/auth.js';
+import { protect, verifyAdmin, verifyBookerOrAdmin } from '../middlewares/auth.js';
 import {  adminAdjustNTRP, closeMatch, getAdmins, removePlayerMatch, toggleAdminRole, togglePaymentStatus, togglePlayerActivation, updatePaymentRecepient } from '../controller/admin.js';
 import { validateObjectId } from '../middlewares/validateFields.js';
 
@@ -12,7 +12,7 @@ router.post('/adjust-ntrp/:userId', protect,verifyAdmin, validateObjectId("userI
 router.post('/remove-player/:matchId/:playerId', protect, verifyAdmin, validateObjectId("playerId"), removePlayerMatch)
 
 router.post('/add-admin', protect, verifyAdmin, toggleAdminRole)
-router.put('/payment/:matchId/:userId', protect, verifyAdmin, togglePaymentStatus)
+router.put('/payment/:matchId/:userId', protect, verifyBookerOrAdmin, togglePaymentStatus)
 
 //wallet
 router.get('/get-admin', protect, verifyAdmin, getAdmins)

--- a/server/routes/match.js
+++ b/server/routes/match.js
@@ -25,7 +25,7 @@ router.post('/leave/:matchId', protect, writeLimiter, validateObjectId("matchId"
 router.post('/invite/accept', acceptInvite)
 router.post('/invite/decline', declineInvite)
 
-router.post('/generate/:id', protect, verifyAdmin, validateObjectId("id"), generateMatches)
+router.post('/generate/:id', protect, verifyBookerOrAdmin, validateObjectId("id"), generateMatches)
 router.put('/update-generate/:matchId', protect, verifyBookerOrAdmin, validateObjectId("matchId"), updateGeneratedMatches)
 router.post('/remove-courts/:matchId/:courtNumber', protect, verifyBookerOrAdmin, removeMatchCourts)
 router.post('/add-courts/:matchId', protect, verifyBookerOrAdmin, validateObjectId("matchId"),  addMatchCourts)


### PR DESCRIPTION
Grant 'booker' the same UI and route permissions previously limited to admins and improve match status user updates.

- Client: MatchPlayers.jsx — show edit controls to users with role 'booker' as well as 'admin'.
- Server routes: admin.js and match.js — /payment and /generate endpoints now use verifyBookerOrAdmin instead of verifyAdmin.
- Server job: matchStatus.js — compute lastMatchPlayed from match endDate, collect/filter player user IDs, update only users with no lastMatchPlayed or an older value, and log the number of users updated.

Files: client/src/components/matches/MatchPlayers.jsx, server/routes/admin.js, server/routes/match.js, server/jobs/matchStatus.js