### PR TITLE
Notify app when session permanently expires

### DIFF
--- a/client/src/API/axios.js
+++ b/client/src/API/axios.js
@@ -17,6 +17,16 @@ export const setAccessToken = (token) => {
 
 export const getAccessToken = () => accessToken;
 
+// --- callback que la app (AuthContext) registra para reaccionar cuando la
+// sesión deja de ser válida de forma definitiva (el refresh token ya no
+// sirve). Así evitamos que cada petición en curso muestre su propio error
+// de "token expirado": la app se entera una vez y limpia el estado. ---
+let onSessionExpired = null;
+
+export const setOnSessionExpired = (callback) => {
+    onSessionExpired = callback;
+};
+
 // --- request interceptor: agrega el access token en memoria ---
 axiosInstance.interceptors.request.use((config) => {
 
@@ -40,8 +50,8 @@ axiosInstance.interceptors.response.use(
     async (error) => {
         const originalRequest = error.config;
 
-        const isAuthRoute = originalRequest.url?.includes("/login")
-            || originalRequest.url?.includes("/refresh");
+        const isAuthRoute = originalRequest?.url?.includes("/login")
+            || originalRequest?.url?.includes("/refresh");
 
         if (error.response?.status === 401 && !originalRequest._retry && !isAuthRoute) {
 
@@ -72,6 +82,13 @@ axiosInstance.interceptors.response.use(
                 refreshQueue.forEach(({ reject }) => reject(refreshError));
                 refreshQueue = [];
                 setAccessToken(null);
+
+                // La sesión ya no es recuperable (refresh token caducado o
+                // inválido). Avisamos a la app en vez de dejar que cada
+                // fetch en curso se encargue por su cuenta de mostrar un
+                // error técnico de token.
+                onSessionExpired?.();
+
                 return Promise.reject(refreshError);
 
             } finally {

--- a/client/src/context/AuthContext.jsx
+++ b/client/src/context/AuthContext.jsx
@@ -3,7 +3,7 @@ import { getNotificationToken, getUserAuth } from "../actions/auth";
 import { getToken } from "firebase/messaging";
 //import { toast } from "react-toastify";
 import { messaging } from "../config/firebase";
-import axiosInstance, { setAccessToken } from "../API/axios"; // ajusta el path si tu archivo se llama distinto
+import axiosInstance, { setAccessToken, setOnSessionExpired } from "../API/axios"; // ajusta el path si tu archivo se llama distinto
 
 export const AuthContext = createContext();
 
@@ -62,6 +62,20 @@ export const AuthProvider = ({ children }) => {
         document.addEventListener("visibilitychange", handleVisibilityChange);
         return () => document.removeEventListener("visibilitychange", handleVisibilityChange);
     }, [tryRestoreSession]);
+
+    // si el interceptor de axios detecta que el refresh token ya no es
+    // válido (sesión caducada de verdad, no un simple access token vencido),
+    // limpiamos aquí el usuario. ProtectedRoute reacciona a isAuthenticated
+    // y redirige a /login solo, sin que ninguna pantalla tenga que mostrar
+    // un error de token.
+    useEffect(() => {
+        setOnSessionExpired(() => {
+            setUser(null);
+            setJustRegistered(false);
+        });
+
+        return () => setOnSessionExpired(null);
+    }, []);
 
     useEffect(() => {
         if (!user) return;

--- a/client/src/context/MatchContext.jsx
+++ b/client/src/context/MatchContext.jsx
@@ -30,7 +30,14 @@ export const MatchesProvider = ({ children }) => {
             setMatches(data)
         } catch (error) {
             console.log(error)
-            toast.error('Error obtaining all matches')
+            // Un 401 significa token/sesión expirada: el interceptor de axios
+            // ya intenta refrescarla y, si falla de verdad, AuthContext cierra
+            // la sesión y la app redirige a /login. No mostramos un toast
+            // técnico para eso. Tampoco molestamos con un toast en los
+            // refrescos silenciosos en segundo plano (isSilent).
+            if (!isSilent && error?.response?.status !== 401) {
+                toast.error('Error obtaining all matches')
+            }
         } finally {
             if (!isSilent) setLoadMatches(false)
         }
@@ -45,7 +52,9 @@ export const MatchesProvider = ({ children }) => {
             setOpenMatches(data);
         } catch (error) {
             console.log(error)
-            toast.error('There was an error obtaining matches')
+            if (!isSilent && error?.response?.status !== 401) {
+                toast.error('There was an error obtaining matches')
+            }
         } finally {
             if (!isSilent) setloadOpenMatches(false);
         }


### PR DESCRIPTION
Add a global session-expired callback to axios so the app is notified when the refresh token is invalid. Export setOnSessionExpired and call it from the response interceptor when refresh fails; also guard originalRequest?.url. Register the callback in AuthContext to clear user state (triggers ProtectedRoute redirect). Suppress 401 and silent-refresh errors from showing toast notifications in MatchContext. Files changed: client/src/API/axios.js, client/src/context/AuthContext.jsx, client/src/context/MatchContext.jsx.