### PR TITLE
Add backup payments, auto-promote & admin removals

### DIFF
--- a/client/src/components/matches/JoinMatch.jsx
+++ b/client/src/components/matches/JoinMatch.jsx
@@ -26,6 +26,9 @@ const JoinMatch = ({ openMatches = [], loading, fetchMatches }) => {
   // 🔵 AÑADIDO
   const [selectedMatch, setSelectedMatch] = useState(null);
   const [paymentModal, setPaymentModal] = useState(false);
+  // 🔵 CAMBIO: nuevo estado — recuerda si el modal de pago se abrió desde
+  // "Join Match" o desde "Join as backup", para saber qué mandar a joinMatch().
+  const [joinAsBackup, setJoinAsBackup] = useState(false);
 
   const walletPaymentAllowed = selectedMatch?.createdBy?.walletPaymentAllowed === true
 
@@ -40,8 +43,8 @@ const JoinMatch = ({ openMatches = [], loading, fetchMatches }) => {
         )} as ${data?.role}`
       );
 
-      fetchMatches();  
-      
+      fetchMatches();
+
     } catch (error) {
       toast.error(error?.response?.data?.message);
     }
@@ -50,6 +53,16 @@ const JoinMatch = ({ openMatches = [], loading, fetchMatches }) => {
   // 🔵 AÑADIDO
   const handleRequestJoin = (match) => {
     setSelectedMatch(match);
+    setJoinAsBackup(false); // 🔵 CAMBIO: aseguramos que no quede el flag de un backup anterior
+    setPaymentModal(true);
+  };
+
+  // 🔵 CAMBIO: handler nuevo, gemelo de handleRequestJoin pero para backup.
+  // Antes el botón "Join as backup" llamaba a onJoin(_id, true) directo,
+  // sin pasar por el modal de pago (ver MatchSummaryTabs.jsx).
+  const handleRequestBackup = (match) => {
+    setSelectedMatch(match);
+    setJoinAsBackup(true);
     setPaymentModal(true);
   };
 
@@ -57,14 +70,18 @@ const JoinMatch = ({ openMatches = [], loading, fetchMatches }) => {
   const handleConfirmJoin = async (paymentMethod) => {
     if (!selectedMatch) return;
 
+    // 🔵 CAMBIO: antes aquí siempre iba "false" (solo se llegaba desde
+    // Join Match). Ahora se manda joinAsBackup para cubrir también el
+    // flujo de backup.
     await handleJoin(
       selectedMatch._id,
-      false,
+      joinAsBackup,
       paymentMethod
     );
 
     setPaymentModal(false);
     setSelectedMatch(null);
+    setJoinAsBackup(false);
     //fetchAllTransactions()
     fetchTransactions()
     loadUser()
@@ -163,7 +180,8 @@ const JoinMatch = ({ openMatches = [], loading, fetchMatches }) => {
                   matchSummary={match}
                   showJoinButton
                   onRequestJoin={handleRequestJoin}
-                  onJoin={handleJoin}
+                  // 🔵 CAMBIO: prop nueva, sustituye a la prop onJoin de antes
+                  onRequestBackup={handleRequestBackup}
                   onLeave={handleLeave}
                 />
               </Card>
@@ -184,6 +202,8 @@ const JoinMatch = ({ openMatches = [], loading, fetchMatches }) => {
           ).toFixed(2)}
           balance={balance}
           walletPaymentAllowed={walletPaymentAllowed}
+          // 🔵 CAMBIO: prop nueva, activa el aviso de backup dentro del modal
+          isBackup={joinAsBackup}
         />
       )}
     </>

--- a/client/src/components/matches/MatchPlayers.jsx
+++ b/client/src/components/matches/MatchPlayers.jsx
@@ -13,16 +13,18 @@ import {
   Empty,
   Tag,
   Switch,
+  Popconfirm,
 } from "antd";
 import {
   ArrowLeftOutlined,
   ExclamationCircleOutlined,
   EditOutlined,
+  UserDeleteOutlined,
 } from "@ant-design/icons";
 import dayjs from "dayjs";
 import MatchDetails from "./MatchDetails";
 import { useAuth } from "../../context/AuthContext";
-import { togglePayment } from "../../actions/admin";
+import { togglePayment, adminRemovePlayer } from "../../actions/admin";
 import colors from "../../themes/colors";
 import ProfilePicture from "../uploads/ProfilePicture";
 import CourtDetail from "./CourtDetail";
@@ -41,7 +43,11 @@ const MatchPlayers = () => {
 
 
   const [loading, setLoading] = useState(false);
+  const [removingId, setRemovingId] = useState(null); // 🔵 CAMBIO: nuevo, para el loading del botón "quitar"
   const [pageLoading, setPageLoading] = useState(false)
+
+  // 🔵 CAMBIO: variable nueva, evita repetir la condición admin/booker por todo el componente
+  const canManage = user?.role === 'admin' || user?.role === 'booker';
 
   //console.log(match)
 
@@ -73,6 +79,23 @@ const MatchPlayers = () => {
       toast.error(response?.data?.message || 'Error setting user payment')
       setLoading(false)
     } finally { setLoading(false) }
+  }
+
+  // 🔵 CAMBIO: handler nuevo. Llama a la acción adminRemovePlayer, que ya
+  // existía en actions/admin.js (apunta a POST /admin/remove-player/:matchId/:playerId)
+  // pero no estaba conectada a ningún botón de la interfaz.
+  const handleRemovePlayer = async (userId) => {
+    try {
+      setRemovingId(userId)
+      await adminRemovePlayer(match._id, userId)
+      toast.success('Player removed from the match')
+      const updated = await getMatch(id)
+      setMatch(updated)
+    } catch ({ response }) {
+      toast.error(response?.data?.message || 'Error removing player')
+    } finally {
+      setRemovingId(null)
+    }
   }
 
   if (pageLoading || !match) return <LoadingSpinner />;
@@ -178,10 +201,11 @@ const MatchPlayers = () => {
                           </div>
 
                         </Flex>
-                        {(user?.role === 'admin' || user?.role === 'booker') && (
+                        {canManage && (
                           <Flex
                             align="center"
                             gap={8}
+                            wrap
                             style={{
                               marginTop: 8,
                               marginLeft: "auto",
@@ -201,6 +225,23 @@ const MatchPlayers = () => {
                               onChange={() => handleTogglePayment(p?.user?._id)}
                               loading={loading}
                             />
+
+                            {/* 🔵 CAMBIO: botón nuevo — antes admin/booker no tenían
+                                forma de retirar a un jugador desde esta pantalla. */}
+                            <Popconfirm
+                              title="Remove player"
+                              description="Remove this player from the match? If they paid with wallet, they'll be refunded and the next backup (if any) will be auto-promoted."
+                              onConfirm={() => handleRemovePlayer(p?.user?._id)}
+                              okText="Remove"
+                              cancelText="Cancel"
+                            >
+                              <Button
+                                danger
+                                size="small"
+                                icon={<UserDeleteOutlined />}
+                                loading={removingId === p?.user?._id}
+                              />
+                            </Popconfirm>
                           </Flex>
                         )}
                       </Flex>
@@ -224,18 +265,46 @@ const MatchPlayers = () => {
                       size="small"
                       style={{ borderLeft: "4px solid #faad14" }}
                     >
-                      <Flex align="center" gap={12}>
-                        <ProfilePicture
-                          user={b}
-                          profilePicture={b?.user?.profilePicture?.url}
-                          size={28}
-                          editable={false}
-                        />
-                        <div>
-                          <Text strong>{b?.user?.name}</Text>
-                          <br />
-                          <Tag color="gold">Backup</Tag>
-                        </div>
+                      <Flex align="center" justify="space-between" wrap gap={12}>
+                        <Flex align="center" gap={12}>
+                          <ProfilePicture
+                            user={b}
+                            profilePicture={b?.user?.profilePicture?.url}
+                            size={28}
+                            editable={false}
+                          />
+                          <div>
+                            <Text strong>{b?.user?.name}</Text>
+                            <br />
+                            <Tag color="gold">Backup</Tag>
+                            {/* 🔵 CAMBIO: tag nuevo — antes no se mostraba nada
+                                del pago de un backup (no existía ese dato). */}
+                            {b?.payment?.method && (
+                              <Tag color={b?.payment?.status === 'held' ? 'success' : 'default'}>
+                                <strong>{b.payment.method}</strong> · {b.payment.status}
+                              </Tag>
+                            )}
+                          </div>
+                        </Flex>
+
+                        {/* 🔵 CAMBIO: botón nuevo, mismo handler que para players */}
+                        {canManage && (
+                          <Popconfirm
+                            title="Remove backup"
+                            description="Remove this backup from the match? If they had wallet funds on hold, they'll be refunded."
+                            onConfirm={() => handleRemovePlayer(b?.user?._id)}
+                            okText="Remove"
+                            cancelText="Cancel"
+                          >
+                            <Button
+                              danger
+                              size="small"
+                              icon={<UserDeleteOutlined />}
+                              loading={removingId === b?.user?._id}
+                              style={{ marginLeft: "auto" }}
+                            />
+                          </Popconfirm>
+                        )}
                       </Flex>
                     </Card>
                   ))}

--- a/client/src/components/matches/MatchSummaryTabs.jsx
+++ b/client/src/components/matches/MatchSummaryTabs.jsx
@@ -20,11 +20,13 @@ import { useNavigate } from "react-router-dom";
 import colors from "../../themes/colors";
 import { useMemo } from "react";
 
+// 🔵 CAMBIO: prop "onJoin" eliminada (ya no se usa para el join directo de
+// backup); prop "onRequestBackup" añadida — ver JoinMatch.jsx.
 const MatchSummaryTabs = ({
     matchSummary,
     showJoinButton = false,
     onRequestJoin,
-    onJoin,
+    onRequestBackup,
     onLeave
 }) => {
 
@@ -236,25 +238,34 @@ const MatchSummaryTabs = ({
                                 </Tooltip>
                             )}
 
-                            <Popconfirm
-                                title="Joining as backup"
-                                description="You are joining this match as backup. Are you sure?"
-                                onConfirm={() => onJoin(_id, true)}
+                            {/*
+                              🔵 CAMBIO: antes este botón era un Popconfirm que
+                              llamaba a onJoin(_id, true) directamente (sin pasar
+                              por el modal de pago, y sin comprobar si el match
+                              estaba Full). Ahora:
+                              - está disabled si status !== "Full" (backup solo
+                                cuando el match está lleno), con tooltip explicando por qué
+                              - al pulsar, abre el modal de pago vía onRequestBackup
+                                (igual que "Join Match" hace con onRequestJoin)
+                            */}
+                            <Tooltip
+                                color="volcano"
+                                title={
+                                    isSuspended
+                                        ? `Your account is suspended until ${dayjs(user.suspendedUntil).format("DD/MM/YYYY HH:mm")}`
+                                        : status !== "Full"
+                                            ? "Backup spots are only available once the match is full"
+                                            : null
+                                }
                             >
-                                <Tooltip
-                                    color="volcano"
-                                    title={
-                                        isSuspended ? `Your account is suspended until ${dayjs(user.suspendedUntil).format("DD/MM/YYYY HH:mm")}` : null
-                                    }
+                                <Button
+                                    type="link" block
+                                    disabled={isSuspended || status !== "Full"}
+                                    onClick={() => onRequestBackup(matchSummary)}
                                 >
-                                    <Button
-                                        type="link" block
-                                        disabled={isSuspended}
-                                    >
-                                        Join as backup
-                                    </Button>
-                                </Tooltip>
-                            </Popconfirm>
+                                    Join as backup
+                                </Button>
+                            </Tooltip>
                         </>
                     ) : (
                         <Popconfirm

--- a/client/src/components/matches/PaymentModal.jsx
+++ b/client/src/components/matches/PaymentModal.jsx
@@ -1,4 +1,4 @@
-import { Modal, Radio, Space, Typography, Card } from "antd";
+import { Modal, Radio, Space, Typography, Card, Alert } from "antd";
 import { useEffect, useState } from "react";
 
 const { Text } = Typography;
@@ -10,7 +10,8 @@ const PaymentModal = ({
     paymentMethods = [],
     price,
     balance,
-    walletPaymentAllowed
+    walletPaymentAllowed,
+    isBackup = false // 🔵 CAMBIO: prop nueva. La pasa JoinMatch.jsx cuando se abre el modal desde "Join as backup".
 }) => {
 
     const [selectedPayment, setSelectedPayment] = useState(null);
@@ -37,13 +38,27 @@ const PaymentModal = ({
             open={open}
             onOk={() => onConfirm(selectedPayment)}
             onCancel={onCancel}
-            okText="Confirm & join"
+            // 🔵 CAMBIO: texto del botón distinto cuando es backup
+            okText={isBackup ? "Confirm & join as backup" : "Confirm & join"}
             cancelText="Cancel"
             okButtonProps={{
                 disabled: !selectedPayment
             }}
             destroyOnHidden
         >
+            {/* 🔵 CAMBIO: bloque nuevo — aviso que pidió el cliente: no hay
+                que pagar todavía, y si es wallet se retiene y se devuelve
+                si el partido no llega a jugarse. */}
+            {isBackup && (
+                <Alert
+                    type="info"
+                    showIcon
+                    style={{ marginBottom: 16 }}
+                    title="You're joining as a backup"
+                    description="You don't need to transfer any money or worry about paying right now. If you select wallet, the amount will be held from your balance, but it will be fully refunded if the match doesn't end up being played. If a spot opens up, you'll be automatically promoted to player."
+                />
+            )}
+
             <p style={{ marginBottom: 16 }}>
                 Price per player <strong>{formatEUR(numericPrice)}</strong>
             </p>

--- a/client/src/router/AppRouter.jsx
+++ b/client/src/router/AppRouter.jsx
@@ -11,8 +11,6 @@ import MatchesTable from '../pages/matches/MatchesTable'
 import Players from '../pages/players/Players'
 import UserProfile from '../pages/profile/UserProfile'
 import MatchPlayers from '../components/matches/MatchPlayers'
-import MatchInviteAccept from '../components/matches/MatchInviteAccept'
-import MatchDeclineInvite from '../components/matches/MatchDeclineInvite'
 import ResetPassword from '../pages/auth/ResetPassword'
 import MatchVote from '../pages/matches/MatchVote'
 import EditMatch from '../pages/matches/EditMatch'
@@ -40,9 +38,11 @@ const AppRouter = () => {
             <Route path="/contact" element={<Contact />} />
             <Route path="/help" element={<Help />} />
 
-
-            <Route path='/match/details/:matchId/accept' element={<MatchInviteAccept />} />
-            <Route path='/match/details/:matchId/decline' element={<MatchDeclineInvite />} />
+            {/* 🔵 CAMBIO: se han eliminado las rutas públicas
+                '/match/details/:matchId/accept' y '/decline' (y los
+                componentes MatchInviteAccept.jsx / MatchDeclineInvite.jsx,
+                que ya no existen). Ahora el paso de backup a player es
+                automático, no requiere un link de email. */}
             <Route path='/auth/reset-password/:token' element={<ResetPassword />} />
           </Route>
 

--- a/server/controller/admin.js
+++ b/server/controller/admin.js
@@ -3,6 +3,12 @@ import { adjustNTRPLevels } from "../jobs/adjustNTRP.js";
 import Match from "../models/Match.js";
 import User from "../models/user.js";
 import WalletTransaction from '../models/Wallet.js'
+import {
+    promoteNextBackup,
+    refundBackupWallet,
+    notifyAutoPromoted,
+    notifyRemovedByAdmin
+} from "../utils/backups.js";
 
 export const closeMatch = async(req, res) =>{
    try {
@@ -134,15 +140,33 @@ export const togglePlayerActivation = async(req, res) =>{
     }
 }
 
+/*
+  🔵 CAMBIO: esta función ya existía, pero solo la podía usar 'admin'
+  (routes/admin.js ahora usa verifyBookerOrAdmin, así que 'booker' también
+  puede). Además tenía un bug: al auto-promocionar un backup hacía
+  match.backUps.shift() + match.players.push(promotedUser) a pelo, sin
+  adaptar el payment al esquema nuevo. Ahora usa promoteNextBackup() (el
+  mismo helper que usa leaveMatch), refund de wallet si aplica, y notifica
+  tanto al retirado como al promocionado.
+
+  Admin / booker manual removal.
+  Unlike a player leaving on their own, this is NOT blocked by the
+  24-hour deadline — an admin or booker can remove a player or backup
+  at any point up until the match starts. Wallet holds are refunded,
+  the next waiting backup (if any) is auto-promoted into the freed
+  spot, and both the removed user and the promoted user are notified.
+*/
 export  const removePlayerMatch = async(req, res) =>{
 
     const session = await mongoose.startSession();
 
-    try {       
+    let removedUserId = null;
+    let promotedUserId = null;
+    const { playerId, matchId } = req.params;
 
-        const {playerId, matchId} = req.params;
+    try {
 
-        await session.withTransaction(async () => {        
+        await session.withTransaction(async () => {
 
         const user = await User.findById(playerId).session(session)
         const match = await Match.findById(matchId).session(session)
@@ -156,28 +180,64 @@ export  const removePlayerMatch = async(req, res) =>{
            throw new Error("Cannot remove player from this match status");
         }
 
-        const isPlayer = match.players.some(p => p.user.toString() === user._id.toString())
-        const isBackup = match.backUps.some(p => p.user.toString() === user._id.toString())
+        const backupObj = match.backUps.find(p => p.user.toString() === playerId.toString())
+        const isBackup = Boolean(backupObj);
+        const isPlayer = match.players.some(p => p.user.toString() === playerId.toString())
 
         if(!isPlayer && !isBackup){
             throw new Error("Player not registered in this match");
         }
 
+        // 🔵 CAMBIO: antes solo hacía el filter/save, sin refund de wallet.
         if(isBackup){
             match.backUps = match.backUps.filter(p => p.user.toString() !== playerId.toString())
 
             await match.save({session})
-            return;            
+
+            await refundBackupWallet({
+                backup: backupObj,
+                userId: playerId,
+                match,
+                session,
+                note: `Backup refund - removed by admin/booker from match ${match._id}`
+            });
+
+            removedUserId = playerId;
+            return;
         }
 
         //removing as player
+        const playerObj = match.players.find(p => p.user.toString() === playerId.toString());
+        const paymentMethod = playerObj?.payment?.method;
+        const paidAmount = match.price / match.maxPlayers;
+
         match.players = match.players.filter(p => p.user.toString() !== playerId.toString())
 
-        //autopromote
-        if(match.backUps.length > 0){
-            const promotedUser = match.backUps.shift();
-            match.players.push(promotedUser)
+        // refund wallet hold, same as a self-initiated leave
+        if(paymentMethod === "wallet"){
+            await User.findByIdAndUpdate(
+                playerId,
+                { $inc: { walletBalance: paidAmount } },
+                { session }
+            );
+
+            const formattedDate = new Date(match.date).toLocaleDateString("es-ES");
+
+            await WalletTransaction.create([{
+                user: playerId,
+                amount: paidAmount,
+                type: "refund",
+                status: "confirmed",
+                note: `Refund - removed by admin/booker from match ${formattedDate}`,
+                match: match._id
+            }], { session });
         }
+
+        // 🔵 CAMBIO: antes -> const promotedUser = match.backUps.shift();
+        // match.players.push(promotedUser) — metía el objeto de backup tal
+        // cual en "players", con un payment que no cuadraba con el esquema.
+        // Ahora usa el mismo helper que leaveMatch, que sí adapta el payment.
+        const promoted = promoteNextBackup(match);
 
         if(match.players.length < match.maxPlayers){
             match.status = 'Open'
@@ -185,7 +245,19 @@ export  const removePlayerMatch = async(req, res) =>{
 
         await match.save({session});
 
+        removedUserId = playerId;
+        promotedUserId = promoted?.userId || null;
+
         })
+
+        // 🔵 CAMBIO: nuevo — antes no se avisaba a nadie al retirarlo.
+        if (removedUserId) {
+            notifyRemovedByAdmin(matchId, removedUserId).catch(console.error);
+        }
+
+        if (promotedUserId) {
+            notifyAutoPromoted(matchId, promotedUserId).catch(console.error);
+        }
 
         return res.status(200).json({
             message: "Removed player from match"
@@ -195,8 +267,8 @@ export  const removePlayerMatch = async(req, res) =>{
         console.log(error)
         return res.status(400).json({
             ok: false,
-            message: 'User not found'
-        });  
+            message: error.message || 'Error removing player from match'
+        });
     }finally{
         session.endSession();
     }

--- a/server/controller/match.js
+++ b/server/controller/match.js
@@ -13,9 +13,10 @@ import {
     isLessThan24h
 } from '../helpers/misc.js';
 import {
-    inviteNextBackup
+    promoteNextBackup,
+    refundBackupWallet,
+    notifyAutoPromoted
 } from '../utils/backups.js';
-import jwt from 'jsonwebtoken';
 import mongoose from 'mongoose';
 import { notifyOtherPlayersOfJoin, sendNewMatchNotification, sendNotification } from '../services/notificationService.js';
 
@@ -82,6 +83,13 @@ export const newMatch = async (req, res) => {
           });
         }
 
+        const pricePerPlayer = Math.round((totalPrice / maxPlayers) * 100) / 100;
+
+        // 🔵 CAMBIO: antes el creador del partido NO quedaba registrado
+        // como jugador (tenía que hacer join él mismo después). Ahora se
+        // añade directamente en el array "players" del create(), con
+        // payment.status = "paid" (pedido explícito: el booker no debe
+        // figurar como "unpaid" en su propio partido).
         const match = await Match.create({
             createdBy: req.user._id,
             location: location._id,
@@ -91,7 +99,17 @@ export const newMatch = async (req, res) => {
             endTime,
             price: totalPrice,
             maxPlayers,
-            paymentMethods: finalPaymentMethods
+            paymentMethods: finalPaymentMethods,
+            players: [{
+                user: req.user._id,
+                joinedAt: new Date(),
+                payment: {
+                    method: "booker",
+                    status: "paid",
+                    amount: pricePerPlayer
+                }
+            }],
+            status: maxPlayers <= 1 ? "Full" : "Open"
         });
 
         /* PUSH NOTIFICATION */ 
@@ -385,6 +403,13 @@ export const joinMatch = async (req, res) => {
       throw new Error("Invalid match ID");
     }
 
+    // 🔵 CAMBIO: antes esta validación solo se hacía para el join normal;
+    // el join como backup no pedía paymentMethod en absoluto. Ahora se
+    // exige siempre, porque el backup también elige método de pago.
+    if (!paymentMethod) {
+      throw new Error("Payment method required");
+    }
+
     const user = await User.findById(userId).session(session);
 
     if(!user) {
@@ -401,16 +426,83 @@ export const joinMatch = async (req, res) => {
       })
     }
 
+    const match = await Match.findById(id).session(session)
+                  .populate('location', 'name')
+                  .populate('createdBy', 'walletPaymentAllowed');
+
+    if (!match) {
+      throw new Error("Match does not exist");
+    }
+
+    const validPaymentMethod = match.paymentMethods.find(
+      pm => pm.type === paymentMethod
+    );
+
+    if (!validPaymentMethod) {
+      throw new Error("Please select a valid payment method");
+    }
+
+    const estimatedPrice = Math.round((match.price / match.maxPlayers) * 100) / 100;
+    const formattedDate = new Date(match.date).toLocaleDateString("es-ES");
+
+    // 🔵 CAMBIO: función nueva, extraída para no duplicar la lógica de
+    // wallet (antes estaba copiada dos veces: una en el join normal con
+    // wallet, y no existía en absoluto para el backup). La usan tanto el
+    // join de player como el de backup y el fallback de auto-backup.
+    /**
+     * Builds the payment sub-document for either a player or a backup join,
+     * and — for wallet payments — deducts/holds the funds and records the
+     * wallet transaction. Throws if the wallet isn't allowed / doesn't have
+     * enough balance. Must run inside the outer transaction.
+     */
+    const buildPayment = async ({ holdLabel }) => {
+      if (paymentMethod === "wallet") {
+        if (!match.createdBy?.walletPaymentAllowed) {
+          throw new Error("Wallet payment not available for this user");
+        }
+
+        if (user.walletBalance < estimatedPrice) {
+          throw new Error("Insufficient balance");
+        }
+
+        user.walletBalance -= estimatedPrice;
+        await user.save({ session });
+
+        await WalletTransaction.create([{
+          user: userId,
+          amount: -estimatedPrice,
+          type: "match_payment",
+          status: "confirmed",
+          note: `${holdLabel} ${formattedDate}`,
+          match: match._id
+        }], { session });
+
+        return { method: "wallet", amount: estimatedPrice };
+      }
+
+      return { method: paymentMethod, amount: estimatedPrice };
+    };
+
     /* ===================================================== */
-    /* BACKUP JOIN (NO WALLET IMPACT)                       */
+    /* BACKUP JOIN — only once the match is Full             */
     /* ===================================================== */
+    // 🔵 CAMBIO: antes se podía unir como backup con el match en estado
+    // "Open" o "Full" (status: { $in: ["Open", "Full"] }). Ahora solo se
+    // permite si ya está "Full". Además, ahora sí pasa por buildPayment()
+    // (antes el backup se guardaba sin payment de ningún tipo).
 
     if (asBackup === true) {
+
+      if (match.status !== "Full") {
+        throw new Error("Backup spots are only available once the match is full");
+      }
+
+      const paid = await buildPayment({ holdLabel: "Backup wallet hold" });
 
       const updatedBackup = await Match.findOneAndUpdate(
         {
           _id: id,
-          status: { $in: ["Open", "Full"] },
+          status: "Full",
           players: { $not: { $elemMatch: { user: userId } } },
           backUps: { $not: { $elemMatch: { user: userId } } },
           $expr: { $lt: [{ $size: "$backUps" }, "$maxBackups"] }
@@ -419,7 +511,13 @@ export const joinMatch = async (req, res) => {
           $push: {
             backUps: {
               user: userId,
-              joinedAt: new Date()
+              joinedAt: new Date(),
+              payment: {
+                method: paid.method,
+                status: paid.method === "wallet" ? "held" : "unpaid",
+                amount: paid.amount,
+                heldAt: paid.method === "wallet" ? new Date() : undefined
+              }
             }
           }
         },
@@ -439,119 +537,10 @@ export const joinMatch = async (req, res) => {
     }
 
     /* ===================================================== */
-    /* NORMAL PLAYER JOIN                                   */
+    /* NORMAL PLAYER JOIN                                    */
     /* ===================================================== */
 
-    if (!paymentMethod) {
-      throw new Error("Payment method required");
-    }
-
-    const match = await Match.findById(id).session(session)
-                  .populate('location', 'name')
-                  .populate('createdBy', 'walletPaymentAllowed');
-
-
-    if (!match) {
-      throw new Error("Match does not exist");
-    }
-
-    const validPaymentMethod = match.paymentMethods.find(
-      pm => pm.type === paymentMethod
-    );
-
-    if (!validPaymentMethod) {
-      throw new Error("Please select a valid payment method");
-    }
-
-    /* ===================================================== */
-    /* WALLET PAYMENT FLOW                                  */
-    /* ===================================================== */
-
-    if (paymentMethod === "wallet") {
-
-      //wallet for allowed only
-      if(!match.createdBy?.walletPaymentAllowed){
-        throw new Error("Wallet payment not available for this user")
-      }
-
-      //  precio estimado por jugador
-      const estimatedPrice = Math.round((match.price / match.maxPlayers) * 100) / 100;;
-
-      if (user.walletBalance < estimatedPrice) {
-        throw new Error("Insufficient balance");
-      }
-
-      //  1 JOIN MATCH
-      const updatedMatch = await Match.findOneAndUpdate(
-        {
-          _id: id,
-          status: { $in: ["Open", "Full"] },
-          players: { $not: { $elemMatch: { user: userId } } },
-          backUps: { $not: { $elemMatch: { user: userId } } },
-          $expr: { $lt: [{ $size: "$players" }, "$maxPlayers"] }
-        },
-        {
-          $push: {
-            players: {
-              user: userId,
-              joinedAt: new Date(),
-              payment: {
-                method: "wallet",
-                status: "paid",
-                amount: estimatedPrice
-              }
-            }
-          }
-        },
-        { new: true, session }
-      );
-
-      if (!updatedMatch) {
-        throw new Error("Match is full");
-      }
-
-      // 2️ UPDATE WALLET
-      user.walletBalance -= estimatedPrice;
-      await user.save({ session });
-
-      // 3️ CREATE WALLET TRANSACTION
-
-      const formattedDate = new Date(match.date).toLocaleDateString("es-ES");
-
-      await WalletTransaction.create([{
-        user: userId,
-        amount: -estimatedPrice,
-        type: "match_payment",
-        status: "confirmed",
-        note: `Match join ${formattedDate}`,
-        match: match._id
-      }], { session });
-
-      // 4️ UPDATE MATCH STATUS
-      if (updatedMatch.players.length === updatedMatch.maxPlayers) {
-        updatedMatch.status = "Full";
-        await updatedMatch.save({ session });
-      }
-
-      await session.commitTransaction(); 
-
-      try {
-        await notifyOtherPlayersOfJoin(userId, user.name, match.location.name, formattedDate);
-      } catch (notifError) {
-        console.error("Error sending join notification:", notifError);
-}
-
-      return res.status(200).json({
-        role: "player",
-        match: updatedMatch
-      });    
-    }
-
-    /* ===================================================== */
-    /* OTHER PAYMENT METHODS (UNPAID)                        */
-    /* ===================================================== */
-
-    const estimatedPrice = Math.round((match.price / match.maxPlayers) * 100) / 100;
+    const paidPlayer = await buildPayment({ holdLabel: "Match join" });
 
     const updatedMatch = await Match.findOneAndUpdate(
       {
@@ -567,9 +556,9 @@ export const joinMatch = async (req, res) => {
             user: userId,
             joinedAt: new Date(),
             payment: {
-              method: paymentMethod,
-              status: "unpaid",
-              amount: estimatedPrice
+              method: paidPlayer.method,
+              status: paidPlayer.method === "wallet" ? "paid" : "unpaid",
+              amount: paidPlayer.amount
             }
           }
         }
@@ -584,16 +573,13 @@ export const joinMatch = async (req, res) => {
         await updatedMatch.save({ session });
       }
 
-      const formattedDate = new Date(match.date).toLocaleDateString("es-ES");
       await session.commitTransaction();
-
-      
 
       try {
         await notifyOtherPlayersOfJoin(userId, user.name, match.location.name, formattedDate );
       } catch (notifError) {
         console.error("Error sending join notification:", notifError);
-}
+      }
 
       return res.status(200).json({
         role: "player",
@@ -602,13 +588,22 @@ export const joinMatch = async (req, res) => {
     }
 
     /* ===================================================== */
-    /* AUTO BACKUP IF FULL                                   */
+    /* AUTO BACKUP IF FULL — reuses the same payment already  */
+    /* collected/held above for the player attempt. The       */
+    /* status: "Full" filter below is the source of truth —   */
+    /* it re-checks the live document, not the stale `match`  */
+    /* fetched at the top of this request.                    */
     /* ===================================================== */
+    // 🔵 CAMBIO: antes, si elegías "wallet" y el match ya estaba lleno,
+    // simplemente daba error "Match is full" y no te metía como backup
+    // (solo pasaba con métodos que no fueran wallet). Ahora es simétrico:
+    // el dinero/hold que ya se calculó arriba (paidPlayer) se reutiliza
+    // tal cual para meterte como backup, sea cual sea el método elegido.
 
     const autoBackup = await Match.findOneAndUpdate(
       {
         _id: id,
-        status: { $in: ["Open", "Full"] },
+        status: "Full",
         players: { $not: { $elemMatch: { user: userId } } },
         backUps: { $not: { $elemMatch: { user: userId } } },
         $expr: { $lt: [{ $size: "$backUps" }, "$maxBackups"] }
@@ -617,7 +612,13 @@ export const joinMatch = async (req, res) => {
         $push: {
           backUps: {
             user: userId,
-            joinedAt: new Date()
+            joinedAt: new Date(),
+            payment: {
+              method: paidPlayer.method,
+              status: paidPlayer.method === "wallet" ? "held" : "unpaid",
+              amount: paidPlayer.amount,
+              heldAt: paidPlayer.method === "wallet" ? new Date() : undefined
+            }
           }
         }
       },
@@ -1150,96 +1151,11 @@ export const addMatchCourts = async (req, res) => {
 };
 
 
-// export const leaveMatch = async (req, res) => {
-
-//     try {
-//         const {
-//             matchId
-//         } = req.params;
-//         const userId = req.user._id.toString();
-
-//         const match = await Match.findById(matchId).populate('backUps.user', 'email')
-
-//         const less24 = isLessThan24h(match.date, match.startTime);     
-
-//         if (!match) return res.status(400).json({
-//             ok: false,
-//             message: 'Match not found'
-//         });
-
-//         if (['Playing', 'Played', 'Cancelled', 'Closed'].includes(match.status)) return res.status(400).json({
-//             ok: false,
-//             message: 'Can only leave open or full matches'
-//         });
-
-//         const isPlayer = match.players.some(p => {
-//             const playerId = p.user._id ? p.user._id.toString() : p.user.toString()
-//             return playerId === userId
-//         })
-        
-
-//         const isBackup = match.backUps.some(b => 
-//             b.user._id.toString() === userId
-//         )
-
-//         if (!isPlayer && !isBackup) return res.status(400).json({
-//             ok: false,
-//             message: 'Player not registered to this match'
-//         });
-
-//            if(less24 && isPlayer) return res.status(200).json({
-//           ok: 'false',
-//           message: 'Cannot leave match if starting in less than 24 hours'
-//         })
-
-//         /* -------------------- */
-//         /* Leaving as BACKUP    */
-//         /* -------------------- */
-//         if (isBackup) {
-//             match.backUps = match.backUps.filter(
-//                 b => b.user._id.toString() !== userId
-//             )
-
-//             await match.save();
-
-//             return res.status(200).json(match)
-//         }
-
-
-//         /* -------------------- */
-//         /* Leaving as player    */
-//         /* -------------------- */
-//         match.players = match.players.filter(p => {
-//             const playerId = p.user._id ? p.user._id.toString() : p.user.toString()
-//             return playerId !== userId
-//         })
-
-//         //reopen for free spots
-//         if (match.players.length < match.maxPlayers) {
-//             match.status = 'Open'
-//         }
-
-//         await match.save();
-
-//         await inviteNextBackup(match)
-
-//         res.status(200).json({
-//             message: 'User removed from match',
-//             match
-//         })
-
-//     } catch (error) {
-//         console.log(error)
-//         res.status(500).json({
-//             ok: false,
-//             message: 'Error leaving match'
-//         });
-//     }
-
-// }
-
-//accept invite
-
+// 🔵 CAMBIO: se han eliminado por completo las funciones acceptInvite()
+// y declineInvite() que estaban aquí (el flujo de invitación por link de
+// email, con token JWT). Ya no hacen falta: cuando se libera una plaza,
+// leaveMatch() y removePlayerMatch() (admin.js) promocionan directamente
+// al siguiente backup con promoteNextBackup() y solo lo notifican.
 export const leaveMatch = async (req, res) => {
   const session = await mongoose.startSession();
   session.startTransaction();
@@ -1280,14 +1196,32 @@ export const leaveMatch = async (req, res) => {
     }
 
     /* -------------------- */
-    /* BACKUP → NO WALLET   */
+    /* BACKUP LEAVE — always allowed, refund wallet hold if any */
     /* -------------------- */
+    // 🔵 CAMBIO: antes esto solo hacía match.backUps = match.backUps.filter(...)
+    // y no tocaba el wallet para nada. Ahora, si el backup había pagado con
+    // wallet (payment.status === 'held'), se le hace refund antes del commit.
     if (isBackup) {
+      const backupObj = match.backUps.find(
+        (b) => b.user._id.toString() === userId
+      );
+
       match.backUps = match.backUps.filter(
         (b) => b.user._id.toString() !== userId
       );
 
       await match.save({ session });
+
+      const formattedDate = new Date(match.date).toLocaleDateString("es-ES");
+
+      await refundBackupWallet({
+        backup: backupObj,
+        userId,
+        match,
+        session,
+        note: `Backup refund - left match ${formattedDate}`
+      });
+
       await session.commitTransaction();
 
       return res.status(200).json(match);
@@ -1315,8 +1249,6 @@ export const leaveMatch = async (req, res) => {
       match.status = "Open";
     }
 
-    await match.save({ session });
-
     // 3️⃣ WALLET REFUND (SOLO SI WALLET)
     if (paymentMethod === "wallet") {
 
@@ -1341,9 +1273,20 @@ export const leaveMatch = async (req, res) => {
       );
     }
 
+    // 4️⃣ 🔵 CAMBIO: antes aquí se llamaba a inviteNextBackup(match), que
+    // mandaba el email con el link de accept/decline y dejaba al backup
+    // en status "invited" esperando respuesta. Ahora se le promociona
+    // directo con promoteNextBackup() (dentro de esta misma transacción)
+    // y solo se le avisa por push/email después del commit (más abajo).
+    const promoted = promoteNextBackup(match);
+
+    await match.save({ session });
+
     await session.commitTransaction();
 
-    await inviteNextBackup(match);
+    if (promoted) {
+      notifyAutoPromoted(match._id, promoted.userId).catch(console.error);
+    }
 
     return res.status(200).json({
       message: "User removed from match",
@@ -1359,258 +1302,5 @@ export const leaveMatch = async (req, res) => {
     });
   } finally {
     session.endSession();
-  }
-};
-
-export const acceptInvite = async (req, res) => {
-  const session = await mongoose.startSession();
-  session.startTransaction();
-
-  try {
-    const { token } = req.query;
-    const { paymentMethod } = req.body;
-
-    if (!token) {
-      throw new Error("Invitation token not provided");
-    }
-
-    if (!paymentMethod) {
-      throw new Error("Please select a payment method");
-    }
-
-    // 🔐 Verify token
-    const { matchId, userId, type } = jwt.verify(
-      token,
-      process.env.JWT_SECRET
-    );
-
-    if (type !== "MATCH_INVITE") {
-      throw new Error("Invalid invitation token");
-    }
-
-    const match = await Match.findById(matchId).session(session);
-
-    if (!match) throw new Error("Match not found");
-
-    // 💰 precio dinámico
-    const estimatedPrice = Math.round((match.price / match.maxPlayers) * 100) / 100;
-
-    /* ===================================================== */
-    /* WALLET FLOW                                           */
-    /* ===================================================== */
-
-    if (paymentMethod === "wallet") {
-
-      const user = await User.findById(userId).session(session);
-
-      if (!user) throw new Error("User not found");
-
-      if (user.walletBalance < estimatedPrice) {
-        throw new Error("Insufficient balance");
-      }
-
-      // 1️⃣ PROMOTE BACKUP → PLAYER
-      const updatedMatch = await Match.findOneAndUpdate(
-        {
-          _id: matchId,
-          "backUps.user": userId,
-          "backUps.status": "invited",
-          $expr: { $lt: [{ $size: "$players" }, "$maxPlayers"] }
-        },
-        {
-          $push: {
-            players: {
-              user: userId,
-              joinedAt: new Date(),
-              payment: {
-                method: "wallet",
-                status: "paid"
-              }
-            }
-          },
-          $pull: {
-            backUps: {
-              user: userId,
-              status: "invited"
-            }
-          }
-        },
-        { new: true, session }
-      );
-
-      if (!updatedMatch) {
-        throw new Error("Invitation invalid, expired, or match full");
-      }
-
-      // 2️⃣ DESCONTAR WALLET
-      await User.findByIdAndUpdate(
-        userId,
-        { $inc: { walletBalance: -estimatedPrice } },
-        { session }
-      );
-
-      // 3️⃣ TRANSACTION
-      const d = new Date(match.date);
-      const formattedDate = `${String(d.getDate()).padStart(2, "0")}/${
-        String(d.getMonth() + 1).padStart(2, "0")
-      }/${d.getFullYear()}`;
-
-      await WalletTransaction.create([{
-        user: userId,
-        amount: -estimatedPrice,
-        type: "match_payment",
-        status: "confirmed",
-        note: `Match invite ${formattedDate}`,
-        match: match._id
-      }], { session });
-
-      // 4️⃣ FULL STATUS
-      if (updatedMatch.players.length === updatedMatch.maxPlayers) {
-        updatedMatch.status = "Full";
-        await updatedMatch.save({ session });
-      }
-
-      await session.commitTransaction();
-
-      return res.status(200).json({
-        ok: true,
-        message: "Joined match successfully",
-        match: updatedMatch
-      });
-    }
-
-    /* ===================================================== */
-    /* OTHER METHODS (UNPAID)                                */
-    /* ===================================================== */
-
-    const updatedMatch = await Match.findOneAndUpdate(
-      {
-        _id: matchId,
-        "backUps.user": userId,
-        "backUps.status": "invited",
-        $expr: { $lt: [{ $size: "$players" }, "$maxPlayers"] }
-      },
-      {
-        $push: {
-          players: {
-            user: userId,
-            joinedAt: new Date(),
-            payment: {
-              method: paymentMethod,
-              status: "unpaid",
-              amount: estimatedPrice
-            }
-          }
-        },
-        $pull: {
-          backUps: {
-            user: userId,
-            status: "invited"
-          }
-        }
-      },
-      { new: true, session }
-    );
-
-    if (!updatedMatch) {
-      throw new Error("Invitation invalid, expired, or match full");
-    }
-
-    if (updatedMatch.players.length === updatedMatch.maxPlayers) {
-      updatedMatch.status = "Full";
-      await updatedMatch.save({ session });
-    }
-
-    await session.commitTransaction();
-
-    return res.status(200).json({
-      ok: true,
-      message: "Joined match successfully",
-      match: updatedMatch
-    });
-
-  } catch (error) {
-    await session.abortTransaction();
-
-    return res.status(401).json({
-      ok: false,
-      message: error.message || "Invalid or expired invitation token"
-    });
-  } finally {
-    session.endSession();
-  }
-};
-
-export const declineInvite = async (req, res) => {
-  try {
-    const { token } = req.query;
-
-    if (!token) {
-      return res.status(400).json({
-        ok: false,
-        message: "Token not provided"
-      });
-    }
-
-    // 🔐 Verify token
-    const { matchId, userId, type } = jwt.verify(
-      token,
-      process.env.JWT_SECRET
-    );
-
-    if (type !== "MATCH_INVITE") {
-      return res.status(400).json({
-        ok: false,
-        message: "Invalid invitation token"
-      });
-    }
-
-    // 🔒 Validate ObjectId
-    if (!mongoose.Types.ObjectId.isValid(matchId)) {
-      return res.status(400).json({
-        ok: false,
-        message: "Invalid match ID"
-      });
-    }
-
-    // 🛡 Atomic removal
-    const updatedMatch = await Match.findOneAndUpdate(
-      {
-        _id: matchId,
-        "backUps.user": userId,
-        "backUps.status": "invited"
-      },
-      {
-        $pull: {
-          backUps: {
-            user: userId,
-            status: "invited"
-          }
-        }
-      },
-      { new: true }
-    );
-
-    if (!updatedMatch) {
-      return res.status(400).json({
-        ok: false,
-        message: "No active invitation to decline"
-      });
-    }
-
-    // 🔄 Invite next backup (safe to call after atomic update)
-    inviteNextBackup(updatedMatch).catch(console.error);
-
-    return res.status(200).json({
-      ok: true,
-      message: "Invitation declined"
-    });
-
-  } catch (error) {
-    console.log(error)
-    return res.status(401).json({
-      ok: false,
-      message: "Invalid or expired invitation token"
-    });
   }
 };

--- a/server/models/Match.js
+++ b/server/models/Match.js
@@ -122,19 +122,34 @@ const matchSchema = new mongoose.Schema({
             }
         }
     }],
+    // 🔵 CAMBIO: los backups ahora tienen su propio "payment", igual que los
+    // players. Antes un backup solo guardaba user/joinedAt/status y no se le
+    // pedía método de pago. Con esto un backup puede elegir método al
+    // unirse (mismo modal que un player) y, si es wallet, se le puede
+    // "retener" (status: 'held') el importe hasta que se promocione,
+    // devuelva (refunded) o se le haga el hold definitivo al pasar a player.
     backUps:[{
         user: {
             type: mongoose.Schema.Types.ObjectId,
             ref: 'User'
         },
         joinedAt: {type: Date, default: Date.now},
-        status:{
-            type: String,
-            enum: ['waiting', 'invited', 'accepted', 'rejected', 'expired'],
-            default: 'waiting'
-        },
-        invitedAt: Date
-
+        payment:{
+            method: {
+                type: String,
+                required: true
+            },
+            status: {
+                type: String,
+                enum: ['unpaid', 'held', 'refunded'], // held = wallet retenido; refunded = ya se le devolvió
+                default: 'unpaid'
+            },
+            amount: {
+                type: Number
+            },
+            heldAt: Date,
+            refundedAt: Date
+        }
     }],
     date: {
         type: Date,

--- a/server/routes/admin.js
+++ b/server/routes/admin.js
@@ -9,7 +9,9 @@ const router = Router();
 router.post('/close-match/:id', protect,verifyAdmin, validateObjectId("id"), closeMatch)
 router.post('/player-activation/:id', protect,verifyAdmin, validateObjectId("id"), togglePlayerActivation)
 router.post('/adjust-ntrp/:userId', protect,verifyAdmin, validateObjectId("userId"), adminAdjustNTRP)
-router.post('/remove-player/:matchId/:playerId', protect, verifyAdmin, validateObjectId("playerId"), removePlayerMatch)
+// 🔵 CAMBIO: era verifyAdmin (solo admin), ahora verifyBookerOrAdmin
+// (admin o booker pueden retirar jugadores/backups, incluso <24h).
+router.post('/remove-player/:matchId/:playerId', protect, verifyBookerOrAdmin, validateObjectId("playerId"), removePlayerMatch)
 
 router.post('/add-admin', protect, verifyAdmin, toggleAdminRole)
 router.put('/payment/:matchId/:userId', protect, verifyBookerOrAdmin, togglePaymentStatus)

--- a/server/routes/match.js
+++ b/server/routes/match.js
@@ -1,8 +1,8 @@
 import {Router} from 'express';
 import { protect, requireVerification, verifyAdmin, verifyBookerOrAdmin } from '../middlewares/auth.js';
-import { acceptInvite, addMatchCourts, 
-declineInvite, generateMatches, getAllMatches,
-getMatch, getOpenMatch, joinMatch, 
+import { addMatchCourts,
+generateMatches, getAllMatches,
+getMatch, getOpenMatch, joinMatch,
 leaveMatch, newMatch, removeMatchCourts,
 updateGeneratedMatches,
 updateMatch, updateMatchStatus } from '../controller/match.js';
@@ -22,8 +22,8 @@ router.get('/view-match/:id', protect, viewMatchesLimiter, validateObjectId("id"
 //post match creation
 router.post('/join/:id', protect, requireVerification, matchLimiter, validateObjectId("id"), joinMatch)
 router.post('/leave/:matchId', protect, writeLimiter, validateObjectId("matchId"), leaveMatch)
-router.post('/invite/accept', acceptInvite)
-router.post('/invite/decline', declineInvite)
+// 🔵 CAMBIO: se han quitado las rutas '/invite/accept' y '/invite/decline'
+// (el flujo de invitación por email ya no existe, ver controller/match.js).
 
 router.post('/generate/:id', protect, verifyBookerOrAdmin, validateObjectId("id"), generateMatches)
 router.put('/update-generate/:matchId', protect, verifyBookerOrAdmin, validateObjectId("matchId"), updateGeneratedMatches)

--- a/server/routes/notification.js
+++ b/server/routes/notification.js
@@ -1,15 +1,6 @@
 
 import {Router} from 'express';
-import { protect, verifyAdmin, verifyBookerOrAdmin } from '../middlewares/auth.js';
-import { acceptInvite, addMatchCourts, 
-declineInvite, generateMatches, getAllMatches,
-getMatch, getOpenMatch, joinMatch, 
-leaveMatch, newMatch, removeMatchCourts,
-updateGeneratedMatches,
-updateMatch, updateMatchStatus } from '../controller/match.js';
-import { createMatchValidator } from '../validator/matchCreateValidator.js';
-import { validateFields, validateObjectId } from '../middlewares/validateFields.js';
-import { matchLimiter, readLimiter, viewMatchesLimiter, writeLimiter } from '../config/expressLimit.js';
+import { protect } from '../middlewares/auth.js';
 import { saveFCMToken } from '../controller/notification.js';
 
 const router = Router();

--- a/server/services/notificationService.js
+++ b/server/services/notificationService.js
@@ -82,3 +82,37 @@ export const sendJoinMatchNotification = async (tokens, playerName, locationName
         console.log(error)
     }
 };
+
+// 🔵 CAMBIO: nueva — push que acompaña a sendAutoPromotedEmail cuando un
+// backup pasa a player automáticamente.
+export const sendAutoPromotedNotification = async (tokens, locationName, formattedDate) => {
+    try {
+        return sendNotification(
+            tokens,
+            "🎾 You're in the match!",
+            `A spot opened up and you were auto-promoted to player for the match on ${formattedDate} at ${locationName}.`,
+            {
+                type: "AUTO_PROMOTED"
+            }
+        );
+    } catch (error) {
+        console.log(error);
+    }
+};
+
+// 🔵 CAMBIO: nueva — push que acompaña a sendRemovedFromMatchEmail cuando
+// un admin/booker retira a alguien manualmente.
+export const sendRemovedFromMatchNotification = async (tokens, locationName, formattedDate) => {
+    try {
+        return sendNotification(
+            tokens,
+            "🎾 Removed from match",
+            `You were removed from the match on ${formattedDate} at ${locationName} by an admin/booker.`,
+            {
+                type: "REMOVED_FROM_MATCH"
+            }
+        );
+    } catch (error) {
+        console.log(error);
+    }
+};

--- a/server/utils/backups.js
+++ b/server/utils/backups.js
@@ -1,53 +1,183 @@
-import jwt from 'jsonwebtoken';
+// 🔵 CAMBIO: este fichero antes solo tenía inviteNextBackup() +
+// generteInvitationToken() (el sistema de invitación por link de email,
+// con accept/decline). Todo eso se ha eliminado. Ahora el fichero expone
+// las piezas del nuevo flujo de auto-promote: promover al siguiente backup
+// directamente, reembolsar su wallet retenido cuando aplique, y notificarlo.
+import User from "../models/user.js";
+import Match from "../models/Match.js";
+import WalletTransaction from "../models/Wallet.js";
+import { formatDate } from "../helpers/misc.js";
 import {
-    sendMatchInviteEmail
-} from './emailService.js'
-import User from "../models/user.js"; //;
+  sendAutoPromotedEmail,
+  sendRemovedFromMatchEmail
+} from "./emailService.js";
+import {
+  sendAutoPromotedNotification,
+  sendRemovedFromMatchNotification
+} from "../services/notificationService.js";
 
+/**
+ * Promotes the next waiting backup (FIFO by joinedAt) into the players list.
+ *
+ * This mutates the given match document IN MEMORY only — the caller is
+ * responsible for persisting it (match.save({ session })) inside their own
+ * transaction, since this can be called from several flows (a player
+ * leaving, an admin/booker removing a player, etc).
+ *
+ * The promoted backup keeps whatever payment method/amount they already
+ * selected when they joined the backup list:
+ *  - if they held funds in their wallet, that payment simply becomes "paid"
+ *    for the player entry (no extra wallet movement needed, it was already
+ *    deducted when they joined as backup)
+ *  - otherwise it carries over as "unpaid", same as a normal unpaid join
+ *
+ * Returns { userId, payment } for the promoted user, or null if nobody
+ * could be promoted (no backups waiting, or the match is already full).
+ */
+export const promoteNextBackup = (match) => {
+  if (!match?.backUps?.length) return null;
+  if (match.players.length >= match.maxPlayers) return null;
 
+  const sorted = [...match.backUps].sort(
+    (a, b) => new Date(a.joinedAt) - new Date(b.joinedAt)
+  );
 
-export const inviteNextBackup = async (match) => {
+  const nextBackup = sorted[0];
+  if (!nextBackup) return null;
+
+  const backupUserId = nextBackup.user?._id
+    ? nextBackup.user._id.toString()
+    : nextBackup.user.toString();
+
+  match.backUps = match.backUps.filter((b) => {
+    const id = b.user?._id ? b.user._id.toString() : b.user.toString();
+    return id !== backupUserId;
+  });
+
+  match.players.push({
+    user: nextBackup.user?._id || nextBackup.user,
+    joinedAt: new Date(),
+    payment: {
+      method: nextBackup.payment?.method,
+      status: nextBackup.payment?.status === "held" ? "paid" : "unpaid",
+      amount: nextBackup.payment?.amount
+    }
+  });
+
+  if (match.players.length >= match.maxPlayers) {
+    match.status = "Full";
+  }
+
+  return { userId: backupUserId, payment: nextBackup.payment };
+};
+
+/**
+ * Refunds a backup's held wallet payment (only acts when payment.method
+ * is "wallet" and payment.status is still "held" — safe to call even when
+ * there is nothing to refund). Must run inside the caller's transaction
+ * (pass the same session).
+ */
+export const refundBackupWallet = async ({ backup, userId, match, session, note }) => {
+  if (!backup?.payment) return false;
+  if (backup.payment.method !== "wallet") return false;
+  if (backup.payment.status !== "held") return false;
+
+  const amount = Number(backup.payment.amount) || 0;
+  if (amount <= 0) return false;
+
+  await User.findByIdAndUpdate(
+    userId,
+    { $inc: { walletBalance: amount } },
+    { session }
+  );
+
+  await WalletTransaction.create(
+    [{
+      user: userId,
+      amount,
+      type: "refund",
+      status: "confirmed",
+      note: note || `Backup refund - match ${match._id}`,
+      match: match._id
+    }],
+    { session }
+  );
+
+  return true;
+};
+
+/**
+ * Best-effort notification (push + email) telling a user they were
+ * automatically promoted from backup to player. Never throws — errors are
+ * logged so they never roll back or block the flow that triggered them.
+ */
+export const notifyAutoPromoted = async (matchId, userId) => {
   try {
-    // 🔎 Find next waiting backup (FIFO by joinedAt)
-    const nextBackup = match.backUps
-      .filter(b => b.status === "waiting")
-      .sort((a, b) => new Date(a.joinedAt) - new Date(b.joinedAt))[0];
+    // Deliberately re-fetched with no session: this always runs after the
+    // triggering transaction has already committed (or as fire-and-forget),
+    // so it must not depend on a session that may already be closed.
+    const [user, match] = await Promise.all([
+      User.findById(userId).select("email fcmToken"),
+      Match.findById(matchId).populate("location", "name")
+    ]);
 
-    if (!nextBackup) return;
+    if (!user || !match) return;
 
-    // 🔄 Change status to invited
-    nextBackup.status = "invited";
-    nextBackup.invitedAt = new Date();
+    const formattedDate = formatDate(match.date);
+    const locationName = match.location?.name || "";
 
-    await match.save();
-
-    // 🔐 Fetch real user from DB (NO populate dependency)
-    const user = await User.findById(nextBackup.user).select("email");
-
-    if (!user) {
-      console.log("User not found when inviting backup");
-      return;
+    if (user.fcmToken) {
+      await sendAutoPromotedNotification(
+        [user.fcmToken],
+        locationName,
+        formattedDate
+      );
     }
 
-    await sendMatchInviteEmail(
-      user.email,
-      match._id,
-      user._id
-    );
-
+    if (user.email) {
+      await sendAutoPromotedEmail(
+        user.email,
+        match,
+        formattedDate
+      );
+    }
   } catch (error) {
-    console.error("Error inviting next backup:", error);
+    console.error("Error notifying auto-promoted user:", error);
   }
 };
 
-export const generteInvitationToken = (matchId, userId) => {
-    return jwt.sign({
-            matchId, 
-            userId,
-            type: 'MATCH_INVITE'
-        },
-        process.env.JWT_SECRET, {
-            expiresIn: '4h'
-        }
-    )
-}
+/**
+ * Best-effort notification (push + email) telling a user an admin/booker
+ * removed them from a match. Never throws.
+ */
+export const notifyRemovedByAdmin = async (matchId, userId) => {
+  try {
+    const [user, match] = await Promise.all([
+      User.findById(userId).select("email fcmToken"),
+      Match.findById(matchId).populate("location", "name")
+    ]);
+
+    if (!user || !match) return;
+
+    const formattedDate = formatDate(match.date);
+    const locationName = match.location?.name || "";
+
+    if (user.fcmToken) {
+      await sendRemovedFromMatchNotification(
+        [user.fcmToken],
+        locationName,
+        formattedDate
+      );
+    }
+
+    if (user.email) {
+      await sendRemovedFromMatchEmail(
+        user.email,
+        match,
+        formattedDate
+      );
+    }
+  } catch (error) {
+    console.error("Error notifying removed user:", error);
+  }
+};

--- a/server/utils/emailService.js
+++ b/server/utils/emailService.js
@@ -1,7 +1,4 @@
 import { Resend } from "resend";
-import Match from "../models/Match.js";
-import { formatDate } from "../helpers/misc.js";
-import { generteInvitationToken } from "./backups.js";
 
 
 
@@ -29,46 +26,59 @@ export  const sendResetPasswordEmail = async(to, resetUrl) =>{
     })
 }
 
-export const sendMatchInviteEmail = async(to, matchId, userId) =>{
-
+// 🔵 CAMBIO: nuevo. Antes aquí estaba sendMatchInviteEmail() (mandaba el
+// link de accept/decline). Se elimina porque el backup ya no necesita
+// aceptar nada manualmente: en cuanto se libera una plaza se le promociona
+// directo y solo se le avisa con este email.
+export const sendAutoPromotedEmail = async (to, match, formattedDate) => {
     try {
- 
+        const resend = new Resend(process.env.RESEND_API_KEY);
 
-    const resend  = new Resend(process.env.RESEND_API_KEY)
+        const matchUrl = `${process.env.FRONTEND_URL}/match/details/${match._id}`;
 
-    const match = await Match.findById(matchId).populate('location', 'name')
-    const token = generteInvitationToken(matchId, userId)
+        await resend.emails.send({
+            from: process.env.FROM_EMAIL,
+            to,
+            subject: "You've been added to the match",
+            html: `
+                <h2>You're in! You've been auto-promoted to player</h2>
+                <p>A spot opened up on the match on ${formattedDate} at ${match?.location?.name || ""}, and you have been automatically moved from the backup list to the player list.</p>
+                <p>Your previously selected payment method still applies. If you used your wallet, the funds you had on hold have now been used for your spot.</p>
+                <p>
+                    <a href="${matchUrl}">View match details</a>
+                </p>
+            `
+        });
 
-    const acceptUrl = `${process.env.FRONTEND_URL}/match/details/${matchId}/accept?token=${token}`;
-    const declineUrl =`${process.env.FRONTEND_URL}/match/details/${matchId}/decline?token=${token}`;
-
-    const formattedDate = formatDate(match.date);
-
-    await resend.emails.send({
-        from: process.env.FROM_EMAIL,
-        to, 
-        subject: "MTC Spot available",
-        html: `
-            <h2>Spot available for match on ${formattedDate} at ${match.location.name}</h2>
-
-            <p>A spot is available for tenis on ${formattedDate} at ${match.location.name}</p>
-            <p>
-                You may join here: <a href='${acceptUrl}'>Accept spot</a>
-            </p>
-            <p>Or you may decline the invitation</p>
-            <small>Declining this invitation will remove you from the queue</small>
-            <p>
-                <a href='${declineUrl}'>Decline spot</a>
-            </p>
-        `
-    })
-
-    console.log(`Email sent to ${to}`)
-        
+        console.log(`Auto-promoted email sent to ${to}`);
     } catch (error) {
-        console.log(error)
+        console.log(error);
     }
-}
+};
+
+// 🔵 CAMBIO: nuevo. Se dispara cuando un admin/booker retira manualmente
+// a un jugador o backup (server/controller/admin.js -> removePlayerMatch).
+export const sendRemovedFromMatchEmail = async (to, match, formattedDate) => {
+    try {
+        const resend = new Resend(process.env.RESEND_API_KEY);
+
+        await resend.emails.send({
+            from: process.env.FROM_EMAIL,
+            to,
+            subject: "You've been removed from a match",
+            html: `
+                <h2>You were removed from a match</h2>
+                <p>An administrator or booker has removed you from the match on ${formattedDate} at ${match?.location?.name || ""}.</p>
+                <p>If you had a wallet payment on hold for this match, it has been refunded to your wallet balance.</p>
+                <p>If you believe this was a mistake, please contact an administrator.</p>
+            `
+        });
+
+        console.log(`Removed-from-match email sent to ${to}`);
+    } catch (error) {
+        console.log(error);
+    }
+};
 
 export const sendVerificationEmail = async (to, name, code) => {
     const resend = new Resend(process.env.RESEND_API_KEY);
@@ -90,113 +100,3 @@ export const sendVerificationEmail = async (to, name, code) => {
         console.log(error);
     }
 };
-
-
-/*
-  ============================================================
-  INACTIVITY EMAILS (jobs/inactivityCheck.js)
-  ============================================================
- */
-const REPLY_TO_EMAIL = process.env.SUPPORT_EMAIL;
-
-export const sendInactivityEmail = async(to, name) =>{
-    try {
-
-        const resend = new Resend(process.env.RESEND_API_KEY);
-
-        await resend.emails.send({
-            from: process.env.FROM_EMAIL,
-            to,
-            replyTo: REPLY_TO_EMAIL,
-            subject: '[MTC] Weekly tennis - We miss you on the court',
-            html: `
-                <h2>Hi ${name},</h2>
-
-                <p>It's been a while since you've joined a Weekly Tennis match.</p>
-
-                <p>Why not sign up for a match this week? If your account remains
-                inactive, we may eventually have to close it.</p>
-
-                <p>
-                    If there's a match available you will see it here:
-                    <a href="${process.env.FRONTEND_URL}/games">View available matches</a>
-                </p>
-
-                <p>If you believe this is a mistake, simply reply to this email.</p>`
-        });
-
-        console.log('First warning inactivity email sent')
-        
-    } catch (error) {
-        console.log(error)
-    }
-}
-
-
-export const sendInactivityEmailFinalWarning = async(to, name) =>{
-    try {
-
-        const resend = new Resend(process.env.RESEND_API_KEY);
-
-        await resend.emails.send({
-            from: process.env.FROM_EMAIL,
-            to,
-            replyTo: REPLY_TO_EMAIL,
-            subject: '[MTC] Weekly tennis - Last warning before your account is closed',
-            html: `
-                <h2>Hi ${name},</h2>
-
-                <p>This is our last reminder to join for you to join us playing a match:</p>
-
-                <p>
-                    We'd like to see you around in our group, so we invite you to join us on future matches. Unfortunately
-                    if your account still shows inactivity we will have to close it. You will still remain in our Whatsapp 
-                    group if you wish. 
-                </p>
-
-                <p>
-                    Matches available, are here:
-                    <a href="${process.env.FRONTEND_URL}/games">View available matches</a>
-                </p>
-
-                <p>If you believe this is a mistake, simply reply to this email.</p>`
-        });
-
-        console.log('Second and final warning inactivity email sent')
-        
-    } catch (error) {
-        console.log(error)
-    }
-}
-
-export const sendAccountCloseEmail = async(to, name) =>{
-    try {
-
-        const resend = new Resend(process.env.RESEND_API_KEY);
-
-        await resend.emails.send({
-            from: process.env.FROM_EMAIL,
-            to,
-            replyTo: REPLY_TO_EMAIL,
-            subject: '[MTC] Weekly tennis - Your account has been closed',
-            html: `
-                <h2>Hi ${name},</h2>
-
-                <p>It's been a while since we've seen you on court, so we have decided to close your account</p>
-
-                <p>
-                    If you believe this is a mistake, or you want to have your account re-activated please reply to this email
-                    and we will review your case
-                </p>
-                
-                <p>Thanks for having been a part of the Madrid tennis community</p>
-                `
-
-        });
-
-        console.log('Account close email sent')
-        
-    } catch (error) {
-        console.log(error)
-    }
-}


### PR DESCRIPTION
Backups can now choose a payment method and (for wallet) hold funds. Match model updated to store backup payment data. Join flow rewritten so "Join as backup" uses the payment modal and wallet holds are created/used consistently; auto-backup fallback reuses held payment. leaveMatch and admin removePlayer now refund held wallet funds, auto-promote the next backup (promoteNextBackup), and send notifications. Removed old invite/accept/decline-by-email flow and routes. Client UI updated (JoinMatch, MatchSummaryTabs, PaymentModal, MatchPlayers) to support backup payments and admin removal button. Added notification/email helpers and routes adjustments to support the new flows.